### PR TITLE
Allow users to zoom in on pages on mobile browsers

### DIFF
--- a/_includes/includes/head.php
+++ b/_includes/includes/head.php
@@ -26,7 +26,7 @@
 <head>
   <meta charset="utf-8">
   <title><?php echo $title; ?></title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel='shortcut icon' href="<?php echo $favicon; ?>">
   <?php foreach($css as $cssFile){ ?>
     <link rel="stylesheet" type="text/css" href="<?php echo $cssFile; ?>">

--- a/_includes/includes/head.php
+++ b/_includes/includes/head.php
@@ -26,7 +26,7 @@
 <head>
   <meta charset="utf-8">
   <title><?php echo $title; ?></title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <link rel='shortcut icon' href="<?php echo $favicon; ?>">
   <?php foreach($css as $cssFile){ ?>
     <link rel="stylesheet" type="text/css" href="<?php echo $cssFile; ?>">

--- a/_includes/includes/head.php
+++ b/_includes/includes/head.php
@@ -26,7 +26,7 @@
 <head>
   <meta charset="utf-8">
   <title><?php echo $title; ?></title>
-  <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" name="viewport">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <link rel='shortcut icon' href="<?php echo $favicon; ?>">
   <?php foreach($css as $cssFile){ ?>
     <link rel="stylesheet" type="text/css" href="<?php echo $cssFile; ?>">


### PR DESCRIPTION
This allows users to zoom in on content on the mobile site. Previously, the perspective and text sized was fixed, which made for bad user experience when, e.g., a users wants to zoom in on text or a particular image. This PR enables zoom in, while keeping the viewport looking correct on mobile browsers.

Related reading:
 - http://adrianroselli.com/2015/10/dont-disable-zoom.html
 - https://stackoverflow.com/a/22544312/6626414
 - https://sitebulb.com/hints/mobile-friendly/the-viewport-meta-tag-prevents-the-user-from-scaling/