### PR TITLE
Adds redirect for alpha iOS help links

### DIFF
--- a/products/iphone-and-ipad/web.config
+++ b/products/iphone-and-ipad/web.config
@@ -3,12 +3,16 @@
     <system.webServer>
         <rewrite>
             <rules>
-                <rule name="Redirect unversioned paths to 11.0/ path">
+                <rule name="Redirect unversioned paths to 'stable' path">
                     <match url="(.*)" />
                     <conditions>
                         <add input="{URL}" pattern="(version-history|\d+\.\d+)(\/)?" negate="true" />
                     </conditions>
                     <action type="Redirect" url="11.0/{R:1}" />
+                </rule>
+                <rule name="Redirect current alpha (or beta, pre-help seeding) version links to the most current (beta/stable) path">
+                    <match url="13\.0/(.*)" />
+                    <action type="Redirect" url="12.0/{R:1}" />
                 </rule>
             </rules>
         </rewrite>


### PR DESCRIPTION
Allows iOS alpha versions to use the previous version's online help from non-existing alpha-version links.  See https://github.com/keymanapp/keyman/pull/2088 for reference.