### PR TITLE
Android main help page:  WET -> DRY with CSS

### DIFF
--- a/_includes/includes/session-embed.php
+++ b/_includes/includes/session-embed.php
@@ -23,6 +23,4 @@ $embed_mac     = $embed == 'macos';
 $embed_linux   = $embed == 'linux';
 $embed_android = $embed == 'android';
 $embed_ios     = $embed == 'ios';
-
-// Generates a stylesheet to control visibility based on embedding state
 ?>

--- a/_includes/includes/session-formfactor.php
+++ b/_includes/includes/session-formfactor.php
@@ -1,0 +1,30 @@
+<?php
+if(!isset($_SESSION)) session_start();
+
+// Which platform are we embedding within?
+if(isset($_REQUEST['formfactor'])) {
+  $formFactor = $_REQUEST['formfactor'];
+  if(!in_array($formFactor, ['detect','phone','tablet'])) {
+    $formFactor = 'detect';
+  }
+} else if(isset($_SESSION['formfactor'])) {
+  $formFactor = $_SESSION['formfactor'];
+} else {
+  $formFactor = 'detect';
+}
+
+// Save our processed session data.
+$_SESSION['formfactor'] = $formFactor;
+
+/* Establishes the default CSS class attribute for reliant pages.
+ * The resulting `$formFactorClass` var is global-referenced
+ * by template.php, which will apply the attribute.
+ *
+ * See function `build_page_class` there for specifics.
+ */
+if($formFactor == "phone") {
+  $formFactorClass = "phone-form";
+} else {
+  $formFactorClass = "tablet-form";
+}
+?>

--- a/_includes/includes/template.php
+++ b/_includes/includes/template.php
@@ -128,6 +128,7 @@
   // This function uses globals defined in the embed/ folder include files, applying
   // classes useful for content filtering between online and in-app help with embed.css.
   function build_page_class($embeddable, $do_embed) {
+    // From session-formfactor.php.
     global $formFactorClass;
 
     // Is set by includes within the embed/ folder.
@@ -136,7 +137,9 @@
       array_push($pageClassComponents, $do_embed ? "embed-on" : "embed-off");
     }
 
-    // Space left here for applying extra classes, like for form-factors.
+    if(isset($formFactorClass)) {
+      array_push($pageClassComponents, $formFactorClass);
+    }
 
     $finalClass = '';
 

--- a/cdn/dev/css/app-info-a.css
+++ b/cdn/dev/css/app-info-a.css
@@ -39,9 +39,12 @@ h2{
 	color: #BA2034;
 }
 
+/*
+	Setting display: block; to ~!important will break CSS rules for phone vs tablet.
+ */
 p img{
 	margin-top: 10px !important;
-	display: block !important;
+	display: block;
 	margin-left: auto !important;
 	margin-right: auto !important;
 	margin-bottom: 10px !important;

--- a/cdn/dev/css/formfactor.css
+++ b/cdn/dev/css/formfactor.css
@@ -5,3 +5,24 @@
 .tablet-form .phone {
     display: none;
 }
+
+#section2 a.phone, #section2 a.tablet {
+    color: #000000;
+}
+
+.tablet-form a.phone {
+    display: block;
+}
+
+.phone-form a.tablet {
+    display: block;
+}
+
+.phone-form #android-mobile-header {
+    background: #f2f2f2;
+}
+
+.tablet-form #android-tablet-header {
+    background: #f2f2f2;
+}
+

--- a/cdn/dev/css/formfactor.css
+++ b/cdn/dev/css/formfactor.css
@@ -1,0 +1,7 @@
+.phone-form .tablet {
+    display: none;
+}
+
+.tablet-form .phone {
+    display: none;
+}

--- a/cdn/dev/js/kmlive.js
+++ b/cdn/dev/js/kmlive.js
@@ -76,23 +76,6 @@ function loaded(){
     }
   }
 
-  // Switch between android docs
-  $('#android-mobile-header').click(function(){
-    $('#android-tablet-tab,#android-tablet-header').removeClass('selected-tab');
-    $('#android-mobile-tab,#android-mobile-header').addClass('selected-tab');
-  });
-  $('#android-tablet-header').click(function(){
-    $('#android-mobile-tab,#android-mobile-header').removeClass('selected-tab');
-    $('#android-tablet-tab,#android-tablet-header').addClass('selected-tab');
-  });
-  if ($(window).width() <= 600) {
-    $('#android-tablet-tab,#android-tablet-header').removeClass('selected-tab');
-    $('#android-mobile-tab,#android-mobile-header').addClass('selected-tab');
-  }
-  
-
-  
-  
   /*!
    * toc - jQuery Table of Contents Plugin
    * v0.3.2

--- a/products/android/12.0/index.php
+++ b/products/android/12.0/index.php
@@ -20,413 +20,416 @@ head([
 
      The Android app needs to add this functionality first, though. -->
 <div id="android-tab-header">
+  <a class="phone" href=".?formfactor=phone">
   <div id="android-mobile-header">
     <h4>Phone</h4>
   </div>
-  <div class="selected-tab" id="android-tablet-header">
+  </a>
+  <a class="tablet" href=".?formfactor=tablet">
+  <div id="android-tablet-header">
     <h4>Tablet</h4>
   </div>
+  </a>
 </div>
+<p>&nbsp;</p>
 
-<div>
-  <p>
-    Keyman for Android lets you type in over 600 languages on Android mobiles and tablets.
-    To get started, here are some helpful hints:
-  </p>
-  <table>
-    <tr>
-      <th colspan="2">Keyboard Keys <br/>(Keyboard Present)</th>
-    </tr>
-    <tr>
-      <td>
-        <img class="phone" id="install-keyboard-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/>
-        <img class="tablet" id="install-keyboard-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/>
-      </td>
-      <td>Select another language/keyboard</td>
-    </tr>
-    <tr>
-      <td>
-        <img class="phone" id="hide-keyboard-ap" src="<?php echo cdn("img/app/12.0/hide-keyboard-ap.png"); ?>"/>
-        <img class="tablet" id="hide-keyboard-at" src="<?php echo cdn("img/app/12.0/hide-keyboard-at.png"); ?>"/>
-      </td>
-      <td>Hide the keyboard</td>
-    </tr>
-    <tr>
-      <td>
-        <img class="phone" id="backspace-ap" src="<?php echo cdn("img/app/12.0/backspace-ap.png"); ?>"/>
-        <img class="tablet" id="backspace-at" src="<?php echo cdn("img/app/12.0/backspace-at.png"); ?>"/>
-      </td>
-      <td>Backspace</td>
-    </tr>
-    <tr>
-      <td>
-        <img class="phone" id="return-ap" src="<?php echo cdn("img/app/12.0/return-ap.png"); ?>"/>
-        <img class="tablet" id="return-at" src="<?php echo cdn("img/app/12.0/return-at.png"); ?>"/>
-      </td>
-      <td>Return</td>
-    </tr>
-    <tr>
-      <td>
-        <img class="phone" id="shift-ap" src="<?php echo cdn("img/app/12.0/shift-ap.png"); ?>"/>
-        <img class="tablet" id="shift-at" src="<?php echo cdn("img/app/12.0/shift-at.png"); ?>"/>
-      </td>
-      <td>Shift key. Long press this key to access the CTRL, ALT and CTRL ALT keys
-        (which can access additional key layers)
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <img class="phone" id="touch-hold-ap" src="<?php echo cdn("img/app/12.0/touch-hold-ap.png"); ?>"/>
-        <img class="tablet" id="touch-hold-at" src="<?php echo cdn("img/app/12.0/touch-hold-at.png"); ?>"/>
-      </td>
-      <td>Keys with a small dot in the top right corner indicate a long press key. Access
-        further functionality by long pressing the key
-      </td>
-    </tr>
-    <tr>
-      <th colspan="2" id="toolbar-ap">Toolbar Icons</th>
-    </tr>
-    <tr>
-      <td><img id="share-ap" src="<?php echo cdn("img/app/12.0/share-a.png"); ?>"/></td>
-      <td>Share your text via Mail, Text, or Twitter</td>
-    </tr>
-    <tr>
-      <td><img id="browser-ap" src="<?php echo cdn("img/app/12.0/browser-a.png"); ?>"/></td>
-      <td>Open the Keyman Browser to use the web in your language</td>
-    </tr>
-    <tr>
-      <td><img id="menu-ap" src="<?php echo cdn("img/app/12.0/menu-icon-a.png"); ?>"/></td>
-      <td>Open the menu for additional options</td>
-    </tr>
-    <tr>
-      <td><img id="font-size-ap" src="<?php echo cdn("img/app/12.0/font-size-a.png"); ?>"/></td>
-      <td>Adjust the font size</td>
-    </tr>
-    <tr>
-      <td><img id="delete-ap" src="<?php echo cdn("img/app/12.0/delete-a.png"); ?>"/></td>
-      <td>Delete all current text</td>
-    </tr>
-    <tr>
-      <td><img id="info-ap" src="<?php echo cdn("img/app/12.0/info-a.png"); ?>"/></td>
-      <td>Load this help page</td>
-    </tr>
-    <tr>
-      <td><img id="get-started-ap" src="<?php echo cdn("img/app/12.0/get-started-a.png"); ?>"/></td>
-      <td>Open the initial setup screen</td>
-    </tr>
-    <tr>
-      <td><img id="settings-ap" src="<?php echo cdn("img/app/12.0/settings-a.png"); ?>"/></td>
-      <td>Open the Keyman Settings screen</td>
-    </tr>
-  </table>
+<p>
+  Keyman for Android lets you type in over 600 languages on Android mobiles and tablets.
+  To get started, here are some helpful hints:
+</p>
+<table>
+  <tr>
+    <th colspan="2">Keyboard Keys <br/>(Keyboard Present)</th>
+  </tr>
+  <tr>
+    <td>
+      <img class="phone" id="install-keyboard-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/>
+      <img class="tablet" id="install-keyboard-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/>
+    </td>
+    <td>Select another language/keyboard</td>
+  </tr>
+  <tr>
+    <td>
+      <img class="phone" id="hide-keyboard-ap" src="<?php echo cdn("img/app/12.0/hide-keyboard-ap.png"); ?>"/>
+      <img class="tablet" id="hide-keyboard-at" src="<?php echo cdn("img/app/12.0/hide-keyboard-at.png"); ?>"/>
+    </td>
+    <td>Hide the keyboard</td>
+  </tr>
+  <tr>
+    <td>
+      <img class="phone" id="backspace-ap" src="<?php echo cdn("img/app/12.0/backspace-ap.png"); ?>"/>
+      <img class="tablet" id="backspace-at" src="<?php echo cdn("img/app/12.0/backspace-at.png"); ?>"/>
+    </td>
+    <td>Backspace</td>
+  </tr>
+  <tr>
+    <td>
+      <img class="phone" id="return-ap" src="<?php echo cdn("img/app/12.0/return-ap.png"); ?>"/>
+      <img class="tablet" id="return-at" src="<?php echo cdn("img/app/12.0/return-at.png"); ?>"/>
+    </td>
+    <td>Return</td>
+  </tr>
+  <tr>
+    <td>
+      <img class="phone" id="shift-ap" src="<?php echo cdn("img/app/12.0/shift-ap.png"); ?>"/>
+      <img class="tablet" id="shift-at" src="<?php echo cdn("img/app/12.0/shift-at.png"); ?>"/>
+    </td>
+    <td>Shift key. Long press this key to access the CTRL, ALT and CTRL ALT keys
+      (which can access additional key layers)
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <img class="phone" id="touch-hold-ap" src="<?php echo cdn("img/app/12.0/touch-hold-ap.png"); ?>"/>
+      <img class="tablet" id="touch-hold-at" src="<?php echo cdn("img/app/12.0/touch-hold-at.png"); ?>"/>
+    </td>
+    <td>Keys with a small dot in the top right corner indicate a long press key. Access
+      further functionality by long pressing the key
+    </td>
+  </tr>
+  <tr>
+    <th colspan="2" id="toolbar-ap">Toolbar Icons</th>
+  </tr>
+  <tr>
+    <td><img id="share-ap" src="<?php echo cdn("img/app/12.0/share-a.png"); ?>"/></td>
+    <td>Share your text via Mail, Text, or Twitter</td>
+  </tr>
+  <tr>
+    <td><img id="browser-ap" src="<?php echo cdn("img/app/12.0/browser-a.png"); ?>"/></td>
+    <td>Open the Keyman Browser to use the web in your language</td>
+  </tr>
+  <tr>
+    <td><img id="menu-ap" src="<?php echo cdn("img/app/12.0/menu-icon-a.png"); ?>"/></td>
+    <td>Open the menu for additional options</td>
+  </tr>
+  <tr>
+    <td><img id="font-size-ap" src="<?php echo cdn("img/app/12.0/font-size-a.png"); ?>"/></td>
+    <td>Adjust the font size</td>
+  </tr>
+  <tr>
+    <td><img id="delete-ap" src="<?php echo cdn("img/app/12.0/delete-a.png"); ?>"/></td>
+    <td>Delete all current text</td>
+  </tr>
+  <tr>
+    <td><img id="info-ap" src="<?php echo cdn("img/app/12.0/info-a.png"); ?>"/></td>
+    <td>Load this help page</td>
+  </tr>
+  <tr>
+    <td><img id="get-started-ap" src="<?php echo cdn("img/app/12.0/get-started-a.png"); ?>"/></td>
+    <td>Open the initial setup screen</td>
+  </tr>
+  <tr>
+    <td><img id="settings-ap" src="<?php echo cdn("img/app/12.0/settings-a.png"); ?>"/></td>
+    <td>Open the Keyman Settings screen</td>
+  </tr>
+</table>
 
-  <h2>Switching between Keyboards</h2>
-  <p>
-    To switch keyboards, follow these steps:
-    <br/><br/>
-    Step 1)
-    <br/>
-    With the keyboard visible, touch the globe key:
-    <br/>
-    <img class="phone" id="globe-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/>
-    <img class="tablet" id="globe-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/>
-    <br/>
-    This will bring up a list of all currently installed languages (the default is English
-    EuroLatin (SIL)). If you have already downloaded additional languages, they will appear here.
-    Simply select them and the keyboard will re-appear with the new language.
-    <br/><br/>
-
-  <h2>Adding New Keyboards</h2>
-  <p>
-    To add keyboards, follow these steps:
-    <br/><br/>
-    Step 1)
-    <br/>
-    Open the menu for additional options. Select 'Settings'
-    <br/><br/>
-    Step 2)
-    <br/>
-    From the Keyman Settings menu, select 'Installed languages'
-    <br/>
-    <img id="settings-language-ap" src="<?php echo cdn("img/app/12.0/settings-language-ap.png"); ?>" />
-    <br/><br/>
-    Step 3)
-    From the 'Installed languages' menu, touch the <span class="command">+</span>
-    button in the bottom right corner of your screen.
-    <br/>
-    <img id="plus-a" src="<?php echo cdn("img/app/12.0/plus-a.png"); ?>" />
-    <br/><br/>
-    Step 4)
-    <br/>
-    A list of all available languages will appear. Scroll through this list until you find
-    the language you want to install. Languages marked with a right arrow have multiple keyboards - for
-    example we have 10+ different Tamil keyboards.
-    <br/>
-    <img class="phone" id="lang-list-ap" src="<?php echo cdn("img/app/12.0/lang-list-ap.png"); ?>"/>
-    <img class="tablet" id="lang-list-at" src="<?php echo cdn("img/app/12.0/lang-list-at.png"); ?>"/>
-    <br/><br/>
-    Select the language and keyboard you want to install - a popup will ask for confirmation,
-    hit the <span class="command">Download</span> button.
-    <br/>
-    <img class="phone" id="confirm-dl-ap" src="<?php echo cdn("img/app/12.0/confirm-dl-ap.png"); ?>"/>
-    <img class="tablet" id="confirm-dl-at" src="<?php echo cdn("img/app/12.0/confirm-dl-at.png"); ?>"/>
-    <br/><br/>
-    Step 5)
-    <br/>
-    Once the download is complete, the new keyboard will be selected. Touch the <span class="command">&larr;</span>
-    button on the top left corner of the popup several times and the new keyboard will become active.
-    <br/>
-    <img class="phone" id="success-ap" src="<?php echo cdn("img/app/12.0/dl-success-ap.png"); ?>"/>
-    <img class="tablet" id="success-at" src="<?php echo cdn("img/app/12.0/dl-success-at.png"); ?>"/>
-    <br/><br/>
-    Alternate Step for System Keyboard)
-    <br/>
-    The Keyman system keyboard has an additional <span class="command">CLOSE KEYMAN</span> button at the bottom left of
-    the "Keyboards" menu. Pushing this button will close Keyman and switch to the next non-Keyman system keyboard.
-    <br/>
-    <img id="close-keyman-a" src="<?php echo cdn("img/app/12.0/close-keyman-a.png"); ?> "/>
-    <br/>
-  </p>
-
-  <h2>Removing a Keyboard</h2>
-  <p>
-    To uninstall a keyboard, follow these steps:
-    <br/><br/>
-    Step 1)
-    <br/>
-    Open the menu for additional options. Select 'Settings'
-    <br/><br/>
-    Step 2)
-    <br/>
-    From the Keyman Settings menu, select 'Installed languages'
-    <br/>
-    <img id="settings-languages-ap" src="<?php echo cdn("img/app/12.0/settings-languages-ap.png"); ?>" />
-    <br/><br/>
-    Step 3)
-    From the 'Installed languages' menu, select the language for the keyboard you want to remove.
-    <br/>
-    <img id="settings-two-installed-languages-ap" src="<?php echo cdn("img/app/12.0/settings-two-installed-languages-ap.png"); ?>" />
-    <br/><br/>
-    Step 4) The language Settings menu lists currently installed keyboards associated with the language.
-    Select the keyboard you want to uninstall
-    <br/>
-    <img id="khmer-settings-ap" src="<?php echo cdn("img/app/12.0/khmer-settings-ap.png"); ?>" />
-    <br/><br/>
-    Step 5)
-    <br/>
-    The bottom of the keyboard settings menu displays an option to uninstall the keyboard.
-    Select 'Uninstall keyboard' to get a prompt to delete the keyboard.
-    <br/>
-    Note: the default 'SIL EuroLatin' keyboard for English cannot be removed.
-    <br/>
-    <img id="settings-khmer-info-ap" src="<?php echo cdn("img/app/12.0/settings-khmer-info-ap.png"); ?>"/>
-    <br/><br/>
-    Step 6)
-    Press "Delete" to uninstall the keyboard.
-    <br/>
-    <img id="confirm-khmer-delete-ap" src="<?php echo cdn("img/app/12.0/confirm-khmer-delete-ap.png"); ?>"/>
-    <br/>
-    You'll see a notification when the keyboard is deleted.
-    <br/>
-    <img class="phone" id="uninstall-notification-ap" src="<?php echo cdn("img/app/12.0/uninstall-notification-ap.png"); ?>"/>
-    <img class="tablet" id="uninstall-notification-at" src="<?php echo cdn("img/app/12.0/uninstall-notification-at.png"); ?>"/>
-  </p>
-
-  <h2>Hotkey</h2>
-  <p>
-    To switch between languages while using an external keyboard (i.e. a bluetooth keyboard), a quick and easy way is to
-    use a hotkey combination. Press and hold 'Ctrl' and then press 'Tab'.
-    You should see a list of languages/keyboards. Tap on any available language of your choice.
-  </p>
-
-  <h2>Accessing Keyboard Help</h2>
-  <p>
-    Step 1) Open the keyboard list by touching the globe key.
-  </p>
-  <p>
-    <img class="phone" id="keyboard-help1-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/>
-    <img class="tablet" id="keyboard-help1-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/>
-  </p>
+<h2>Switching between Keyboards</h2>
+<p>
+  To switch keyboards, follow these steps:
+  <br/><br/>
+  Step 1)
   <br/>
-  <p>
-    Step 2) Touch the info icon for your keyboard.
-  </p>
-  <p><img id="keyboard-help2-ap" src="<?php echo cdn("img/app/12.0/info-a-gray.png"); ?>"/></p>
+  With the keyboard visible, touch the globe key:
   <br/>
-
-  <h2>Installing System Wide Keyboards</h2>
-  <p>
-    Step 1) Open the Keyman app and select the menu for additional options.
-    The screenshots below are of a device running Android 9.0 Pie.
-  </p>
-  <p>
-    <img class="phone" id="settings1-ap" src="<?php echo cdn("img/app/12.0/settings1-ap.png"); ?>"/>
-    <img class="tablet" id="settings1-at" src="<?php echo cdn("img/app/12.0/settings1-at.png"); ?>"/>
-  </p>
+  <img class="phone" id="globe-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/>
+  <img class="tablet" id="globe-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/>
   <br/>
-  <p>
-    Step 2) Select 'Get Started' and then select 'Enable Keyman as system-wide keyboard'.
-  </p>
-  <p>
-    <img class="phone" id="settings2-ap" src="<?php echo cdn("img/app/12.0/settings2-ap.png"); ?>"/>
-    <img class="tablet" id="settings2-at" src="<?php echo cdn("img/app/12.0/settings2-at.png"); ?>"/>
-  </p>
-  <br/>
-  <p>
-    This will open an Android settings screen for 'Available virtual keyboard'.
-  </p>
-  <p>
-    <img class="phone" id="settings3-ap" src="<?php echo cdn("img/app/12.0/settings3-ap.png"); ?>"/>
-    <img class="tablet" id="settings3-at" src="<?php echo cdn("img/app/12.0/settings3-at.png"); ?>"/>
-  </p>
-  <br/>
-  <p>
-    Step 3) Enable 'Keyman' as an available virtual keyboard.
-    This will bring up two confirmation dialogs.
-  </p>
-  <p>
-    <img class="phone" id="settings4-ap" src="<?php echo cdn("img/app/12.0/settings4-ap.png"); ?>"/>
-    <img class="tablet" id="settings4-at" src="<?php echo cdn("img/app/12.0/settings4-at.png"); ?>"/>
-  </p>
-  <br/>
-  <p>
-    <img class="phone" id="settings5-ap" src="<?php echo cdn("img/app/12.0/settings5-ap.png"); ?>"/>
-    <img class="tablet" id="settings5-at" src="<?php echo cdn("img/app/12.0/settings5-at.png"); ?>"/>
-  </p>
-  <br/>
-  <p>
-    Select 'OK' on both. Now when the on-screen keyboard appears for apps other than Keyman,
-    you'll see a keyboard icon at the bottom right.
-  </p>
-  <p>
-    <img class="phone" id="settings6-ap" src="<?php echo cdn("img/app/12.0/settings6-ap.png"); ?>"/>
-    <img class="tablet" id="settings6-at" src="<?php echo cdn("img/app/12.0/settings6-at.png"); ?>"/>
-  </p>
-  <br/>
-  <p>
-    Click the keyboard icon whenever you want to change the current system keyboard.
-  </p>
-  <p>
-    <img class="phone" id="settings7-ap" src="<?php echo cdn("img/app/12.0/settings7-ap.png"); ?>"/>
-    <img class="tablet" id="settings7-at" src="<?php echo cdn("img/app/12.0/settings7-at.png"); ?>"/>
-  </p>
+  This will bring up a list of all currently installed languages (the default is English
+  EuroLatin (SIL)). If you have already downloaded additional languages, they will appear here.
+  Simply select them and the keyboard will re-appear with the new language.
   <br/><br/>
 
-  <h2>Installing Custom Keyboards</h2>
-  <p>
-    Step 1) Click the link to your custom keyboard package file. The link in this example is for Khmer Angkor keyboard.
-  </p>
-  <p>
-    <img class="phone" id="dist-url-screen-ap" src="<?= cdn('img/app/12.0/dist-url-screen-ap.png')?>">
-    <img class="tablet" id="dist-url-screen-at" src="<?= cdn('img/app/12.0/dist-url-screen-at.png')?>">
-  </p>
-  <p>
-    Step 2) Once the KMP file is on your device, you will need to browse to the KMP file and select it.
-    From the Keyman menu, select 'Settings'.
-    <br/>
-    From the Keyman Settings menu, select 'Add Keyboard from Device'.
-  </p>
-  <p><img id="settings-add-keyboard-from-device-ap" src="<?php echo cdn("img/app/12.0/settings-language-ap.png"); ?>" /></p>
-  <p>
-    The device will launch a file browser where you'll browse to the directory of your KMP file.
-    A common place to look is the "Downloads" folder.
-  </p>
-  <p>
-    <img class="phone" id="dist-file-browser-ap" src="<?= cdn('img/app/12.0/dist-file-browser-ap.png')?>">
-    <img class="tablet" id="dist-file-browser-at" src="<?= cdn('img/app/12.0/dist-file-browser-at.png')?>">
-  </p>
-  <p>
-    Selecting the KMP file should bring you to Step 3)
-  </p>
-  <p>
-    Step 3) On Android 6.0 (Marshmallow) and higher, mobile apps need to request permissions to access storage. Keyman
-    for Android needs access to read storage for installing the KMP file. At the dialog, select "ALLOW". Once authorized,
-    Keyman for Android won't need to ask for storage permission again, unless the user revokes or uninstalls the app.
-  </p>
-  <p>
-    <img class="phone" id="dist-storrage-permission-ap" src="<?php echo cdn("img/app/12.0/dist-storage-permission-ap.png"); ?>"/>
-    <img class="tablet" id="dist-storrage-permission-at" src="<?php echo cdn("img/app/12.0/dist-storage-permission-at.png"); ?>"/>
-  </p>
-  <p>
-    Older versions of Android grant Storage permissions at app installation time, so those users can skip this step.
-  </p>
-  <p>
-    Step 4) Keyman for Android will parse the metadata in the package. If the keyboard package includes a "welcome.htm"
-    file, this will be displayed at the confirmation to install the keyboard package.
-  </p>
-  <p>
-    <img class="phone" id="dist-welcome-ap" src="<?php echo cdn("img/app/12.0/dist-welcome-ap.png"); ?>"/>
-    <img class="tablet" id="dist-welcome-at" src="<?php echo cdn("img/app/12.0/dist-welcome-at.png"); ?>"/>
-  </p>
-  <p>
-    If "welcome.htm" is not included, a generic page with the package ID and package version will be shown. Click the
-    left "Install" button to install the entire keyboard package.
-  </p>
-  <p>
-    Step 5) All the keyboards in the package are installed as a group. In this example, the package only has the
-    "Khmer Angkor" keyboard, so it becomes the active keyboard.
-  </p>
-  <p>
-    <img class="phone" id="dist-install1-ap" src="<?php echo cdn("img/app/12.0/dist-install1-ap.png"); ?>"/>
-    <img class="tablet" id="dist-install1-at" src="<?php echo cdn("img/app/12.0/dist-install1-at.png"); ?>"/>
-  </p>
-  <p>
-    Once the keyboard has been downloaded, you should be able to use it as normal.
-    <br/>
-    To learn how to create a custom installable keyboard,
-    <a href="https://help.keyman.com/developer/12.0/guides/distribute/">click here</a>.
-  </p>
+<h2>Adding New Keyboards</h2>
+<p>
+  To add keyboards, follow these steps:
+  <br/><br/>
+  Step 1)
+  <br/>
+  Open the menu for additional options. Select 'Settings'
+  <br/><br/>
+  Step 2)
+  <br/>
+  From the Keyman Settings menu, select 'Installed languages'
+  <br/>
+  <img id="settings-language-ap" src="<?php echo cdn("img/app/12.0/settings-language-ap.png"); ?>" />
+  <br/><br/>
+  Step 3)
+  From the 'Installed languages' menu, touch the <span class="command">+</span>
+  button in the bottom right corner of your screen.
+  <br/>
+  <img id="plus-a" src="<?php echo cdn("img/app/12.0/plus-a.png"); ?>" />
+  <br/><br/>
+  Step 4)
+  <br/>
+  A list of all available languages will appear. Scroll through this list until you find
+  the language you want to install. Languages marked with a right arrow have multiple keyboards - for
+  example we have 10+ different Tamil keyboards.
+  <br/>
+  <img class="phone" id="lang-list-ap" src="<?php echo cdn("img/app/12.0/lang-list-ap.png"); ?>"/>
+  <img class="tablet" id="lang-list-at" src="<?php echo cdn("img/app/12.0/lang-list-at.png"); ?>"/>
+  <br/><br/>
+  Select the language and keyboard you want to install - a popup will ask for confirmation,
+  hit the <span class="command">Download</span> button.
+  <br/>
+  <img class="phone" id="confirm-dl-ap" src="<?php echo cdn("img/app/12.0/confirm-dl-ap.png"); ?>"/>
+  <img class="tablet" id="confirm-dl-at" src="<?php echo cdn("img/app/12.0/confirm-dl-at.png"); ?>"/>
+  <br/><br/>
+  Step 5)
+  <br/>
+  Once the download is complete, the new keyboard will be selected. Touch the <span class="command">&larr;</span>
+  button on the top left corner of the popup several times and the new keyboard will become active.
+  <br/>
+  <img class="phone" id="success-ap" src="<?php echo cdn("img/app/12.0/dl-success-ap.png"); ?>"/>
+  <img class="tablet" id="success-at" src="<?php echo cdn("img/app/12.0/dl-success-at.png"); ?>"/>
+  <br/><br/>
+  Alternate Step for System Keyboard)
+  <br/>
+  The Keyman system keyboard has an additional <span class="command">CLOSE KEYMAN</span> button at the bottom left of
+  the "Keyboards" menu. Pushing this button will close Keyman and switch to the next non-Keyman system keyboard.
+  <br/>
+  <img id="close-keyman-a" src="<?php echo cdn("img/app/12.0/close-keyman-a.png"); ?> "/>
+  <br/>
+</p>
 
-  <h2>Granting storage permission</h2>
-  <p>
-    If Keyman for Android is permanently denied storage access, attempts to install custom keyboards will fail with the
-    notification "Storage permission request was denied". Perform these steps to grant Keyman for Android access to storage
-  </p>
-  <p>
-    Step 1) Go to Android Settings.
-    <br/>
-    Step 2) Depending on your device, click "Apps", "Apps &amp; notifications", or "App permissions" and grant Keyman
-    storage permission. The screenshot below is from Android 9.0 Pie.
-  </p>
-  <p>
-    <img class="phone" id="keyman-storage-permission-ap" src="<?php echo cdn("img/app/12.0/keyman-storage-permission-ap.png"); ?>"/>
-    <img class="tablet" id="keyman-storage-permission-at" src="<?php echo cdn("img/app/12.0/keyman-storage-permission-at.png"); ?>"/>
-  </p>
+<h2>Removing a Keyboard</h2>
+<p>
+  To uninstall a keyboard, follow these steps:
+  <br/><br/>
+  Step 1)
+  <br/>
+  Open the menu for additional options. Select 'Settings'
+  <br/><br/>
+  Step 2)
+  <br/>
+  From the Keyman Settings menu, select 'Installed languages'
+  <br/>
+  <img id="settings-languages-ap" src="<?php echo cdn("img/app/12.0/settings-languages-ap.png"); ?>" />
+  <br/><br/>
+  Step 3)
+  From the 'Installed languages' menu, select the language for the keyboard you want to remove.
+  <br/>
+  <img id="settings-two-installed-languages-ap" src="<?php echo cdn("img/app/12.0/settings-two-installed-languages-ap.png"); ?>" />
+  <br/><br/>
+  Step 4) The language Settings menu lists currently installed keyboards associated with the language.
+  Select the keyboard you want to uninstall
+  <br/>
+  <img id="khmer-settings-ap" src="<?php echo cdn("img/app/12.0/khmer-settings-ap.png"); ?>" />
+  <br/><br/>
+  Step 5)
+  <br/>
+  The bottom of the keyboard settings menu displays an option to uninstall the keyboard.
+  Select 'Uninstall keyboard' to get a prompt to delete the keyboard.
+  <br/>
+  Note: the default 'SIL EuroLatin' keyboard for English cannot be removed.
+  <br/>
+  <img id="settings-khmer-info-ap" src="<?php echo cdn("img/app/12.0/settings-khmer-info-ap.png"); ?>"/>
+  <br/><br/>
+  Step 6)
+  Press "Delete" to uninstall the keyboard.
+  <br/>
+  <img id="confirm-khmer-delete-ap" src="<?php echo cdn("img/app/12.0/confirm-khmer-delete-ap.png"); ?>"/>
+  <br/>
+  You'll see a notification when the keyboard is deleted.
+  <br/>
+  <img class="phone" id="uninstall-notification-ap" src="<?php echo cdn("img/app/12.0/uninstall-notification-ap.png"); ?>"/>
+  <img class="tablet" id="uninstall-notification-at" src="<?php echo cdn("img/app/12.0/uninstall-notification-at.png"); ?>"/>
+</p>
 
-  <h2>Use the Keyman Browser</h2>
-  <p>
-    Step 1) Click the Keyman Browser button in the Keyman app
-    <br/>
-    Step 2) Enter the URL of a website to visit into the address bar, for example <strong>google.com</strong>.
-    Keyman Browser will load the page and detect your language if it is present, and reformat it to show your
-    language instead of square boxes.
-    <br/>
-    Step 3) Use the bookmark button to save the current page for browsing later.
-    <br/>
-    Step 4) Use the Globe icon to swap between languages.
-  </p>
+<h2>Hotkey</h2>
+<p>
+  To switch between languages while using an external keyboard (i.e. a bluetooth keyboard), a quick and easy way is to
+  use a hotkey combination. Press and hold 'Ctrl' and then press 'Tab'.
+  You should see a list of languages/keyboards. Tap on any available language of your choice.
+</p>
 
-  <h2>Integrate Keyman with your App or Website</h2>
-  <p>
-    If you are interested in learning how Keyman can be integrated into your own app or
-    website, visit <a href="https://keyman.com/engine/">keyman.com/engine</a>
-  </p>
+<h2>Accessing Keyboard Help</h2>
+<p>
+  Step 1) Open the keyboard list by touching the globe key.
+</p>
+<p>
+  <img class="phone" id="keyboard-help1-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/>
+  <img class="tablet" id="keyboard-help1-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/>
+</p>
+<br/>
+<p>
+  Step 2) Touch the info icon for your keyboard.
+</p>
+<p><img id="keyboard-help2-ap" src="<?php echo cdn("img/app/12.0/info-a-gray.png"); ?>"/></p>
+<br/>
 
-  <h2>Further Help</h2>
-  <p>
-    For more information on Keyman, visit <a href="https://keyman.com">keyman.com</a>
-    <br/><br/>
-    For more information on Keyman for Android, visit <a href="https://keyman.com/android">keyman.com/android</a>
-  </p>
+<h2>Installing System Wide Keyboards</h2>
+<p>
+  Step 1) Open the Keyman app and select the menu for additional options.
+  The screenshots below are of a device running Android 9.0 Pie.
+</p>
+<p>
+  <img class="phone" id="settings1-ap" src="<?php echo cdn("img/app/12.0/settings1-ap.png"); ?>"/>
+  <img class="tablet" id="settings1-at" src="<?php echo cdn("img/app/12.0/settings1-at.png"); ?>"/>
+</p>
+<br/>
+<p>
+  Step 2) Select 'Get Started' and then select 'Enable Keyman as system-wide keyboard'.
+</p>
+<p>
+  <img class="phone" id="settings2-ap" src="<?php echo cdn("img/app/12.0/settings2-ap.png"); ?>"/>
+  <img class="tablet" id="settings2-at" src="<?php echo cdn("img/app/12.0/settings2-at.png"); ?>"/>
+</p>
+<br/>
+<p>
+  This will open an Android settings screen for 'Available virtual keyboard'.
+</p>
+<p>
+  <img class="phone" id="settings3-ap" src="<?php echo cdn("img/app/12.0/settings3-ap.png"); ?>"/>
+  <img class="tablet" id="settings3-at" src="<?php echo cdn("img/app/12.0/settings3-at.png"); ?>"/>
+</p>
+<br/>
+<p>
+  Step 3) Enable 'Keyman' as an available virtual keyboard.
+  This will bring up two confirmation dialogs.
+</p>
+<p>
+  <img class="phone" id="settings4-ap" src="<?php echo cdn("img/app/12.0/settings4-ap.png"); ?>"/>
+  <img class="tablet" id="settings4-at" src="<?php echo cdn("img/app/12.0/settings4-at.png"); ?>"/>
+</p>
+<br/>
+<p>
+  <img class="phone" id="settings5-ap" src="<?php echo cdn("img/app/12.0/settings5-ap.png"); ?>"/>
+  <img class="tablet" id="settings5-at" src="<?php echo cdn("img/app/12.0/settings5-at.png"); ?>"/>
+</p>
+<br/>
+<p>
+  Select 'OK' on both. Now when the on-screen keyboard appears for apps other than Keyman,
+  you'll see a keyboard icon at the bottom right.
+</p>
+<p>
+  <img class="phone" id="settings6-ap" src="<?php echo cdn("img/app/12.0/settings6-ap.png"); ?>"/>
+  <img class="tablet" id="settings6-at" src="<?php echo cdn("img/app/12.0/settings6-at.png"); ?>"/>
+</p>
+<br/>
+<p>
+  Click the keyboard icon whenever you want to change the current system keyboard.
+</p>
+<p>
+  <img class="phone" id="settings7-ap" src="<?php echo cdn("img/app/12.0/settings7-ap.png"); ?>"/>
+  <img class="tablet" id="settings7-at" src="<?php echo cdn("img/app/12.0/settings7-at.png"); ?>"/>
+</p>
+<br/><br/>
 
-  <div class="content-online">
-    <h2>Keyman for Android Documentation Versions</h2>
+<h2>Installing Custom Keyboards</h2>
+<p>
+  Step 1) Click the link to your custom keyboard package file. The link in this example is for Khmer Angkor keyboard.
+</p>
+<p>
+  <img class="phone" id="dist-url-screen-ap" src="<?= cdn('img/app/12.0/dist-url-screen-ap.png')?>">
+  <img class="tablet" id="dist-url-screen-at" src="<?= cdn('img/app/12.0/dist-url-screen-at.png')?>">
+</p>
+<p>
+  Step 2) Once the KMP file is on your device, you will need to browse to the KMP file and select it.
+  From the Keyman menu, select 'Settings'.
+  <br/>
+  From the Keyman Settings menu, select 'Add Keyboard from Device'.
+</p>
+<p><img id="settings-add-keyboard-from-device-ap" src="<?php echo cdn("img/app/12.0/settings-language-ap.png"); ?>" /></p>
+<p>
+  The device will launch a file browser where you'll browse to the directory of your KMP file.
+  A common place to look is the "Downloads" folder.
+</p>
+<p>
+  <img class="phone" id="dist-file-browser-ap" src="<?= cdn('img/app/12.0/dist-file-browser-ap.png')?>">
+  <img class="tablet" id="dist-file-browser-at" src="<?= cdn('img/app/12.0/dist-file-browser-at.png')?>">
+</p>
+<p>
+  Selecting the KMP file should bring you to Step 3)
+</p>
+<p>
+  Step 3) On Android 6.0 (Marshmallow) and higher, mobile apps need to request permissions to access storage. Keyman
+  for Android needs access to read storage for installing the KMP file. At the dialog, select "ALLOW". Once authorized,
+  Keyman for Android won't need to ask for storage permission again, unless the user revokes or uninstalls the app.
+</p>
+<p>
+  <img class="phone" id="dist-storrage-permission-ap" src="<?php echo cdn("img/app/12.0/dist-storage-permission-ap.png"); ?>"/>
+  <img class="tablet" id="dist-storrage-permission-at" src="<?php echo cdn("img/app/12.0/dist-storage-permission-at.png"); ?>"/>
+</p>
+<p>
+  Older versions of Android grant Storage permissions at app installation time, so those users can skip this step.
+</p>
+<p>
+  Step 4) Keyman for Android will parse the metadata in the package. If the keyboard package includes a "welcome.htm"
+  file, this will be displayed at the confirmation to install the keyboard package.
+</p>
+<p>
+  <img class="phone" id="dist-welcome-ap" src="<?php echo cdn("img/app/12.0/dist-welcome-ap.png"); ?>"/>
+  <img class="tablet" id="dist-welcome-at" src="<?php echo cdn("img/app/12.0/dist-welcome-at.png"); ?>"/>
+</p>
+<p>
+  If "welcome.htm" is not included, a generic page with the package ID and package version will be shown. Click the
+  left "Install" button to install the entire keyboard package.
+</p>
+<p>
+  Step 5) All the keyboards in the package are installed as a group. In this example, the package only has the
+  "Khmer Angkor" keyboard, so it becomes the active keyboard.
+</p>
+<p>
+  <img class="phone" id="dist-install1-ap" src="<?php echo cdn("img/app/12.0/dist-install1-ap.png"); ?>"/>
+  <img class="tablet" id="dist-install1-at" src="<?php echo cdn("img/app/12.0/dist-install1-at.png"); ?>"/>
+</p>
+<p>
+  Once the keyboard has been downloaded, you should be able to use it as normal.
+  <br/>
+  To learn how to create a custom installable keyboard,
+  <a href="https://help.keyman.com/developer/12.0/guides/distribute/">click here</a>.
+</p>
 
-    <ul>
-      <li><a href='../12.0/'>Keyman for Android 12.0 Documentation</a></li>
-      <li><a href='../11.0/'>Keyman for Android 11.0 Documentation</a></li>
-      <li><a href='../10.0/'>Keyman for Android 10.0 Documentation</a></li>
-      <li><a href='../2.0/'>Keyman for Android 2.0 Documentation</a></li>
-    </ul>
-  </div>
+<h2>Granting storage permission</h2>
+<p>
+  If Keyman for Android is permanently denied storage access, attempts to install custom keyboards will fail with the
+  notification "Storage permission request was denied". Perform these steps to grant Keyman for Android access to storage
+</p>
+<p>
+  Step 1) Go to Android Settings.
+  <br/>
+  Step 2) Depending on your device, click "Apps", "Apps &amp; notifications", or "App permissions" and grant Keyman
+  storage permission. The screenshot below is from Android 9.0 Pie.
+</p>
+<p>
+  <img class="phone" id="keyman-storage-permission-ap" src="<?php echo cdn("img/app/12.0/keyman-storage-permission-ap.png"); ?>"/>
+  <img class="tablet" id="keyman-storage-permission-at" src="<?php echo cdn("img/app/12.0/keyman-storage-permission-at.png"); ?>"/>
+</p>
+
+<h2>Use the Keyman Browser</h2>
+<p>
+  Step 1) Click the Keyman Browser button in the Keyman app
+  <br/>
+  Step 2) Enter the URL of a website to visit into the address bar, for example <strong>google.com</strong>.
+  Keyman Browser will load the page and detect your language if it is present, and reformat it to show your
+  language instead of square boxes.
+  <br/>
+  Step 3) Use the bookmark button to save the current page for browsing later.
+  <br/>
+  Step 4) Use the Globe icon to swap between languages.
+</p>
+
+<h2>Integrate Keyman with your App or Website</h2>
+<p>
+  If you are interested in learning how Keyman can be integrated into your own app or
+  website, visit <a href="https://keyman.com/engine/">keyman.com/engine</a>
+</p>
+
+<h2>Further Help</h2>
+<p>
+  For more information on Keyman, visit <a href="https://keyman.com">keyman.com</a>
+  <br/><br/>
+  For more information on Keyman for Android, visit <a href="https://keyman.com/android">keyman.com/android</a>
+</p>
+
+<div class="content-online">
+  <h2>Keyman for Android Documentation Versions</h2>
+
+  <ul>
+    <li><a href='../12.0/'>Keyman for Android 12.0 Documentation</a></li>
+    <li><a href='../11.0/'>Keyman for Android 11.0 Documentation</a></li>
+    <li><a href='../10.0/'>Keyman for Android 10.0 Documentation</a></li>
+    <li><a href='../2.0/'>Keyman for Android 2.0 Documentation</a></li>
+  </ul>
 </div>

--- a/products/android/12.0/index.php
+++ b/products/android/12.0/index.php
@@ -43,36 +43,36 @@ head([
   </tr>
   <tr>
     <td>
-      <img class="phone" id="install-keyboard-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/>
-      <img class="tablet" id="install-keyboard-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/>
+      <img class="phone" id="install-keyboard-ap" src="<?= cdn("img/app/12.0/globe-ap.png"); ?>"/>
+      <img class="tablet" id="install-keyboard-at" src="<?= cdn("img/app/12.0/globe-at.png"); ?>"/>
     </td>
     <td>Select another language/keyboard</td>
   </tr>
   <tr>
     <td>
-      <img class="phone" id="hide-keyboard-ap" src="<?php echo cdn("img/app/12.0/hide-keyboard-ap.png"); ?>"/>
-      <img class="tablet" id="hide-keyboard-at" src="<?php echo cdn("img/app/12.0/hide-keyboard-at.png"); ?>"/>
+      <img class="phone" id="hide-keyboard-ap" src="<?= cdn("img/app/12.0/hide-keyboard-ap.png"); ?>"/>
+      <img class="tablet" id="hide-keyboard-at" src="<?= cdn("img/app/12.0/hide-keyboard-at.png"); ?>"/>
     </td>
     <td>Hide the keyboard</td>
   </tr>
   <tr>
     <td>
-      <img class="phone" id="backspace-ap" src="<?php echo cdn("img/app/12.0/backspace-ap.png"); ?>"/>
-      <img class="tablet" id="backspace-at" src="<?php echo cdn("img/app/12.0/backspace-at.png"); ?>"/>
+      <img class="phone" id="backspace-ap" src="<?= cdn("img/app/12.0/backspace-ap.png"); ?>"/>
+      <img class="tablet" id="backspace-at" src="<?= cdn("img/app/12.0/backspace-at.png"); ?>"/>
     </td>
     <td>Backspace</td>
   </tr>
   <tr>
     <td>
-      <img class="phone" id="return-ap" src="<?php echo cdn("img/app/12.0/return-ap.png"); ?>"/>
-      <img class="tablet" id="return-at" src="<?php echo cdn("img/app/12.0/return-at.png"); ?>"/>
+      <img class="phone" id="return-ap" src="<?= cdn("img/app/12.0/return-ap.png"); ?>"/>
+      <img class="tablet" id="return-at" src="<?= cdn("img/app/12.0/return-at.png"); ?>"/>
     </td>
     <td>Return</td>
   </tr>
   <tr>
     <td>
-      <img class="phone" id="shift-ap" src="<?php echo cdn("img/app/12.0/shift-ap.png"); ?>"/>
-      <img class="tablet" id="shift-at" src="<?php echo cdn("img/app/12.0/shift-at.png"); ?>"/>
+      <img class="phone" id="shift-ap" src="<?= cdn("img/app/12.0/shift-ap.png"); ?>"/>
+      <img class="tablet" id="shift-at" src="<?= cdn("img/app/12.0/shift-at.png"); ?>"/>
     </td>
     <td>Shift key. Long press this key to access the CTRL, ALT and CTRL ALT keys
       (which can access additional key layers)
@@ -80,8 +80,8 @@ head([
   </tr>
   <tr>
     <td>
-      <img class="phone" id="touch-hold-ap" src="<?php echo cdn("img/app/12.0/touch-hold-ap.png"); ?>"/>
-      <img class="tablet" id="touch-hold-at" src="<?php echo cdn("img/app/12.0/touch-hold-at.png"); ?>"/>
+      <img class="phone" id="touch-hold-ap" src="<?= cdn("img/app/12.0/touch-hold-ap.png"); ?>"/>
+      <img class="tablet" id="touch-hold-at" src="<?= cdn("img/app/12.0/touch-hold-at.png"); ?>"/>
     </td>
     <td>Keys with a small dot in the top right corner indicate a long press key. Access
       further functionality by long pressing the key
@@ -91,35 +91,35 @@ head([
     <th colspan="2" id="toolbar-ap">Toolbar Icons</th>
   </tr>
   <tr>
-    <td><img id="share-ap" src="<?php echo cdn("img/app/12.0/share-a.png"); ?>"/></td>
+    <td><img id="share-ap" src="<?= cdn("img/app/12.0/share-a.png"); ?>"/></td>
     <td>Share your text via Mail, Text, or Twitter</td>
   </tr>
   <tr>
-    <td><img id="browser-ap" src="<?php echo cdn("img/app/12.0/browser-a.png"); ?>"/></td>
+    <td><img id="browser-ap" src="<?= cdn("img/app/12.0/browser-a.png"); ?>"/></td>
     <td>Open the Keyman Browser to use the web in your language</td>
   </tr>
   <tr>
-    <td><img id="menu-ap" src="<?php echo cdn("img/app/12.0/menu-icon-a.png"); ?>"/></td>
+    <td><img id="menu-ap" src="<?= cdn("img/app/12.0/menu-icon-a.png"); ?>"/></td>
     <td>Open the menu for additional options</td>
   </tr>
   <tr>
-    <td><img id="font-size-ap" src="<?php echo cdn("img/app/12.0/font-size-a.png"); ?>"/></td>
+    <td><img id="font-size-ap" src="<?= cdn("img/app/12.0/font-size-a.png"); ?>"/></td>
     <td>Adjust the font size</td>
   </tr>
   <tr>
-    <td><img id="delete-ap" src="<?php echo cdn("img/app/12.0/delete-a.png"); ?>"/></td>
+    <td><img id="delete-ap" src="<?= cdn("img/app/12.0/delete-a.png"); ?>"/></td>
     <td>Delete all current text</td>
   </tr>
   <tr>
-    <td><img id="info-ap" src="<?php echo cdn("img/app/12.0/info-a.png"); ?>"/></td>
+    <td><img id="info-ap" src="<?= cdn("img/app/12.0/info-a.png"); ?>"/></td>
     <td>Load this help page</td>
   </tr>
   <tr>
-    <td><img id="get-started-ap" src="<?php echo cdn("img/app/12.0/get-started-a.png"); ?>"/></td>
+    <td><img id="get-started-ap" src="<?= cdn("img/app/12.0/get-started-a.png"); ?>"/></td>
     <td>Open the initial setup screen</td>
   </tr>
   <tr>
-    <td><img id="settings-ap" src="<?php echo cdn("img/app/12.0/settings-a.png"); ?>"/></td>
+    <td><img id="settings-ap" src="<?= cdn("img/app/12.0/settings-a.png"); ?>"/></td>
     <td>Open the Keyman Settings screen</td>
   </tr>
 </table>
@@ -132,8 +132,8 @@ head([
   <br/>
   With the keyboard visible, touch the globe key:
   <br/>
-  <img class="phone" id="globe-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/>
-  <img class="tablet" id="globe-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/>
+  <img class="phone" id="globe-ap" src="<?= cdn("img/app/12.0/globe-ap.png"); ?>"/>
+  <img class="tablet" id="globe-at" src="<?= cdn("img/app/12.0/globe-at.png"); ?>"/>
   <br/>
   This will bring up a list of all currently installed languages (the default is English
   EuroLatin (SIL)). If you have already downloaded additional languages, they will appear here.
@@ -152,13 +152,13 @@ head([
   <br/>
   From the Keyman Settings menu, select 'Installed languages'
   <br/>
-  <img id="settings-language-ap" src="<?php echo cdn("img/app/12.0/settings-language-ap.png"); ?>" />
+  <img id="settings-language-ap" src="<?= cdn("img/app/12.0/settings-language-ap.png"); ?>" />
   <br/><br/>
   Step 3)
   From the 'Installed languages' menu, touch the <span class="command">+</span>
   button in the bottom right corner of your screen.
   <br/>
-  <img id="plus-a" src="<?php echo cdn("img/app/12.0/plus-a.png"); ?>" />
+  <img id="plus-a" src="<?= cdn("img/app/12.0/plus-a.png"); ?>" />
   <br/><br/>
   Step 4)
   <br/>
@@ -166,29 +166,29 @@ head([
   the language you want to install. Languages marked with a right arrow have multiple keyboards - for
   example we have 10+ different Tamil keyboards.
   <br/>
-  <img class="phone" id="lang-list-ap" src="<?php echo cdn("img/app/12.0/lang-list-ap.png"); ?>"/>
-  <img class="tablet" id="lang-list-at" src="<?php echo cdn("img/app/12.0/lang-list-at.png"); ?>"/>
+  <img class="phone" id="lang-list-ap" src="<?= cdn("img/app/12.0/lang-list-ap.png"); ?>"/>
+  <img class="tablet" id="lang-list-at" src="<?= cdn("img/app/12.0/lang-list-at.png"); ?>"/>
   <br/><br/>
   Select the language and keyboard you want to install - a popup will ask for confirmation,
   hit the <span class="command">Download</span> button.
   <br/>
-  <img class="phone" id="confirm-dl-ap" src="<?php echo cdn("img/app/12.0/confirm-dl-ap.png"); ?>"/>
-  <img class="tablet" id="confirm-dl-at" src="<?php echo cdn("img/app/12.0/confirm-dl-at.png"); ?>"/>
+  <img class="phone" id="confirm-dl-ap" src="<?= cdn("img/app/12.0/confirm-dl-ap.png"); ?>"/>
+  <img class="tablet" id="confirm-dl-at" src="<?= cdn("img/app/12.0/confirm-dl-at.png"); ?>"/>
   <br/><br/>
   Step 5)
   <br/>
   Once the download is complete, the new keyboard will be selected. Touch the <span class="command">&larr;</span>
   button on the top left corner of the popup several times and the new keyboard will become active.
   <br/>
-  <img class="phone" id="success-ap" src="<?php echo cdn("img/app/12.0/dl-success-ap.png"); ?>"/>
-  <img class="tablet" id="success-at" src="<?php echo cdn("img/app/12.0/dl-success-at.png"); ?>"/>
+  <img class="phone" id="success-ap" src="<?= cdn("img/app/12.0/dl-success-ap.png"); ?>"/>
+  <img class="tablet" id="success-at" src="<?= cdn("img/app/12.0/dl-success-at.png"); ?>"/>
   <br/><br/>
   Alternate Step for System Keyboard)
   <br/>
   The Keyman system keyboard has an additional <span class="command">CLOSE KEYMAN</span> button at the bottom left of
   the "Keyboards" menu. Pushing this button will close Keyman and switch to the next non-Keyman system keyboard.
   <br/>
-  <img id="close-keyman-a" src="<?php echo cdn("img/app/12.0/close-keyman-a.png"); ?> "/>
+  <img id="close-keyman-a" src="<?= cdn("img/app/12.0/close-keyman-a.png"); ?> "/>
   <br/>
 </p>
 
@@ -204,17 +204,17 @@ head([
   <br/>
   From the Keyman Settings menu, select 'Installed languages'
   <br/>
-  <img id="settings-languages-ap" src="<?php echo cdn("img/app/12.0/settings-languages-ap.png"); ?>" />
+  <img id="settings-languages-ap" src="<?= cdn("img/app/12.0/settings-languages-ap.png"); ?>" />
   <br/><br/>
   Step 3)
   From the 'Installed languages' menu, select the language for the keyboard you want to remove.
   <br/>
-  <img id="settings-two-installed-languages-ap" src="<?php echo cdn("img/app/12.0/settings-two-installed-languages-ap.png"); ?>" />
+  <img id="settings-two-installed-languages-ap" src="<?= cdn("img/app/12.0/settings-two-installed-languages-ap.png"); ?>" />
   <br/><br/>
   Step 4) The language Settings menu lists currently installed keyboards associated with the language.
   Select the keyboard you want to uninstall
   <br/>
-  <img id="khmer-settings-ap" src="<?php echo cdn("img/app/12.0/khmer-settings-ap.png"); ?>" />
+  <img id="khmer-settings-ap" src="<?= cdn("img/app/12.0/khmer-settings-ap.png"); ?>" />
   <br/><br/>
   Step 5)
   <br/>
@@ -223,17 +223,17 @@ head([
   <br/>
   Note: the default 'SIL EuroLatin' keyboard for English cannot be removed.
   <br/>
-  <img id="settings-khmer-info-ap" src="<?php echo cdn("img/app/12.0/settings-khmer-info-ap.png"); ?>"/>
+  <img id="settings-khmer-info-ap" src="<?= cdn("img/app/12.0/settings-khmer-info-ap.png"); ?>"/>
   <br/><br/>
   Step 6)
   Press "Delete" to uninstall the keyboard.
   <br/>
-  <img id="confirm-khmer-delete-ap" src="<?php echo cdn("img/app/12.0/confirm-khmer-delete-ap.png"); ?>"/>
+  <img id="confirm-khmer-delete-ap" src="<?= cdn("img/app/12.0/confirm-khmer-delete-ap.png"); ?>"/>
   <br/>
   You'll see a notification when the keyboard is deleted.
   <br/>
-  <img class="phone" id="uninstall-notification-ap" src="<?php echo cdn("img/app/12.0/uninstall-notification-ap.png"); ?>"/>
-  <img class="tablet" id="uninstall-notification-at" src="<?php echo cdn("img/app/12.0/uninstall-notification-at.png"); ?>"/>
+  <img class="phone" id="uninstall-notification-ap" src="<?= cdn("img/app/12.0/uninstall-notification-ap.png"); ?>"/>
+  <img class="tablet" id="uninstall-notification-at" src="<?= cdn("img/app/12.0/uninstall-notification-at.png"); ?>"/>
 </p>
 
 <h2>Hotkey</h2>
@@ -248,14 +248,14 @@ head([
   Step 1) Open the keyboard list by touching the globe key.
 </p>
 <p>
-  <img class="phone" id="keyboard-help1-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/>
-  <img class="tablet" id="keyboard-help1-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/>
+  <img class="phone" id="keyboard-help1-ap" src="<?= cdn("img/app/12.0/globe-ap.png"); ?>"/>
+  <img class="tablet" id="keyboard-help1-at" src="<?= cdn("img/app/12.0/globe-at.png"); ?>"/>
 </p>
 <br/>
 <p>
   Step 2) Touch the info icon for your keyboard.
 </p>
-<p><img id="keyboard-help2-ap" src="<?php echo cdn("img/app/12.0/info-a-gray.png"); ?>"/></p>
+<p><img id="keyboard-help2-ap" src="<?= cdn("img/app/12.0/info-a-gray.png"); ?>"/></p>
 <br/>
 
 <h2>Installing System Wide Keyboards</h2>
@@ -264,24 +264,24 @@ head([
   The screenshots below are of a device running Android 9.0 Pie.
 </p>
 <p>
-  <img class="phone" id="settings1-ap" src="<?php echo cdn("img/app/12.0/settings1-ap.png"); ?>"/>
-  <img class="tablet" id="settings1-at" src="<?php echo cdn("img/app/12.0/settings1-at.png"); ?>"/>
+  <img class="phone" id="settings1-ap" src="<?= cdn("img/app/12.0/settings1-ap.png"); ?>"/>
+  <img class="tablet" id="settings1-at" src="<?= cdn("img/app/12.0/settings1-at.png"); ?>"/>
 </p>
 <br/>
 <p>
   Step 2) Select 'Get Started' and then select 'Enable Keyman as system-wide keyboard'.
 </p>
 <p>
-  <img class="phone" id="settings2-ap" src="<?php echo cdn("img/app/12.0/settings2-ap.png"); ?>"/>
-  <img class="tablet" id="settings2-at" src="<?php echo cdn("img/app/12.0/settings2-at.png"); ?>"/>
+  <img class="phone" id="settings2-ap" src="<?= cdn("img/app/12.0/settings2-ap.png"); ?>"/>
+  <img class="tablet" id="settings2-at" src="<?= cdn("img/app/12.0/settings2-at.png"); ?>"/>
 </p>
 <br/>
 <p>
   This will open an Android settings screen for 'Available virtual keyboard'.
 </p>
 <p>
-  <img class="phone" id="settings3-ap" src="<?php echo cdn("img/app/12.0/settings3-ap.png"); ?>"/>
-  <img class="tablet" id="settings3-at" src="<?php echo cdn("img/app/12.0/settings3-at.png"); ?>"/>
+  <img class="phone" id="settings3-ap" src="<?= cdn("img/app/12.0/settings3-ap.png"); ?>"/>
+  <img class="tablet" id="settings3-at" src="<?= cdn("img/app/12.0/settings3-at.png"); ?>"/>
 </p>
 <br/>
 <p>
@@ -289,13 +289,13 @@ head([
   This will bring up two confirmation dialogs.
 </p>
 <p>
-  <img class="phone" id="settings4-ap" src="<?php echo cdn("img/app/12.0/settings4-ap.png"); ?>"/>
-  <img class="tablet" id="settings4-at" src="<?php echo cdn("img/app/12.0/settings4-at.png"); ?>"/>
+  <img class="phone" id="settings4-ap" src="<?= cdn("img/app/12.0/settings4-ap.png"); ?>"/>
+  <img class="tablet" id="settings4-at" src="<?= cdn("img/app/12.0/settings4-at.png"); ?>"/>
 </p>
 <br/>
 <p>
-  <img class="phone" id="settings5-ap" src="<?php echo cdn("img/app/12.0/settings5-ap.png"); ?>"/>
-  <img class="tablet" id="settings5-at" src="<?php echo cdn("img/app/12.0/settings5-at.png"); ?>"/>
+  <img class="phone" id="settings5-ap" src="<?= cdn("img/app/12.0/settings5-ap.png"); ?>"/>
+  <img class="tablet" id="settings5-at" src="<?= cdn("img/app/12.0/settings5-at.png"); ?>"/>
 </p>
 <br/>
 <p>
@@ -303,16 +303,16 @@ head([
   you'll see a keyboard icon at the bottom right.
 </p>
 <p>
-  <img class="phone" id="settings6-ap" src="<?php echo cdn("img/app/12.0/settings6-ap.png"); ?>"/>
-  <img class="tablet" id="settings6-at" src="<?php echo cdn("img/app/12.0/settings6-at.png"); ?>"/>
+  <img class="phone" id="settings6-ap" src="<?= cdn("img/app/12.0/settings6-ap.png"); ?>"/>
+  <img class="tablet" id="settings6-at" src="<?= cdn("img/app/12.0/settings6-at.png"); ?>"/>
 </p>
 <br/>
 <p>
   Click the keyboard icon whenever you want to change the current system keyboard.
 </p>
 <p>
-  <img class="phone" id="settings7-ap" src="<?php echo cdn("img/app/12.0/settings7-ap.png"); ?>"/>
-  <img class="tablet" id="settings7-at" src="<?php echo cdn("img/app/12.0/settings7-at.png"); ?>"/>
+  <img class="phone" id="settings7-ap" src="<?= cdn("img/app/12.0/settings7-ap.png"); ?>"/>
+  <img class="tablet" id="settings7-at" src="<?= cdn("img/app/12.0/settings7-at.png"); ?>"/>
 </p>
 <br/><br/>
 
@@ -330,7 +330,7 @@ head([
   <br/>
   From the Keyman Settings menu, select 'Add Keyboard from Device'.
 </p>
-<p><img id="settings-add-keyboard-from-device-ap" src="<?php echo cdn("img/app/12.0/settings-language-ap.png"); ?>" /></p>
+<p><img id="settings-add-keyboard-from-device-ap" src="<?= cdn("img/app/12.0/settings-language-ap.png"); ?>" /></p>
 <p>
   The device will launch a file browser where you'll browse to the directory of your KMP file.
   A common place to look is the "Downloads" folder.
@@ -348,8 +348,8 @@ head([
   Keyman for Android won't need to ask for storage permission again, unless the user revokes or uninstalls the app.
 </p>
 <p>
-  <img class="phone" id="dist-storrage-permission-ap" src="<?php echo cdn("img/app/12.0/dist-storage-permission-ap.png"); ?>"/>
-  <img class="tablet" id="dist-storrage-permission-at" src="<?php echo cdn("img/app/12.0/dist-storage-permission-at.png"); ?>"/>
+  <img class="phone" id="dist-storrage-permission-ap" src="<?= cdn("img/app/12.0/dist-storage-permission-ap.png"); ?>"/>
+  <img class="tablet" id="dist-storrage-permission-at" src="<?= cdn("img/app/12.0/dist-storage-permission-at.png"); ?>"/>
 </p>
 <p>
   Older versions of Android grant Storage permissions at app installation time, so those users can skip this step.
@@ -359,8 +359,8 @@ head([
   file, this will be displayed at the confirmation to install the keyboard package.
 </p>
 <p>
-  <img class="phone" id="dist-welcome-ap" src="<?php echo cdn("img/app/12.0/dist-welcome-ap.png"); ?>"/>
-  <img class="tablet" id="dist-welcome-at" src="<?php echo cdn("img/app/12.0/dist-welcome-at.png"); ?>"/>
+  <img class="phone" id="dist-welcome-ap" src="<?= cdn("img/app/12.0/dist-welcome-ap.png"); ?>"/>
+  <img class="tablet" id="dist-welcome-at" src="<?= cdn("img/app/12.0/dist-welcome-at.png"); ?>"/>
 </p>
 <p>
   If "welcome.htm" is not included, a generic page with the package ID and package version will be shown. Click the
@@ -371,8 +371,8 @@ head([
   "Khmer Angkor" keyboard, so it becomes the active keyboard.
 </p>
 <p>
-  <img class="phone" id="dist-install1-ap" src="<?php echo cdn("img/app/12.0/dist-install1-ap.png"); ?>"/>
-  <img class="tablet" id="dist-install1-at" src="<?php echo cdn("img/app/12.0/dist-install1-at.png"); ?>"/>
+  <img class="phone" id="dist-install1-ap" src="<?= cdn("img/app/12.0/dist-install1-ap.png"); ?>"/>
+  <img class="tablet" id="dist-install1-at" src="<?= cdn("img/app/12.0/dist-install1-at.png"); ?>"/>
 </p>
 <p>
   Once the keyboard has been downloaded, you should be able to use it as normal.
@@ -393,8 +393,8 @@ head([
   storage permission. The screenshot below is from Android 9.0 Pie.
 </p>
 <p>
-  <img class="phone" id="keyman-storage-permission-ap" src="<?php echo cdn("img/app/12.0/keyman-storage-permission-ap.png"); ?>"/>
-  <img class="tablet" id="keyman-storage-permission-at" src="<?php echo cdn("img/app/12.0/keyman-storage-permission-at.png"); ?>"/>
+  <img class="phone" id="keyman-storage-permission-ap" src="<?= cdn("img/app/12.0/keyman-storage-permission-ap.png"); ?>"/>
+  <img class="tablet" id="keyman-storage-permission-at" src="<?= cdn("img/app/12.0/keyman-storage-permission-at.png"); ?>"/>
 </p>
 
 <h2>Use the Keyman Browser</h2>

--- a/products/android/12.0/index.php
+++ b/products/android/12.0/index.php
@@ -1,10 +1,11 @@
 <?php
 require_once('includes/template.php');
 require_once('includes/session-embed.php');
+require_once('includes/session-formfactor.php');
 
 head([
     'title' => 'Keyman for Android Help',
-    'css' => ['template.css', 'app-info-a.css', 'embed.css'],
+    'css' => ['template.css', 'app-info-a.css', 'embed.css', 'formfactor.css'],
     'embedded' => $embed_android
 ]);
 ?>
@@ -24,6 +25,7 @@ head([
     <h4>Tablet</h4>
   </div>
 </div>
+
 <div class="tab" id="android-mobile-tab">
   <p>
     Keyman for Android lets you type in over 600 languages on Android mobiles and tablets.

--- a/products/android/12.0/index.php
+++ b/products/android/12.0/index.php
@@ -15,8 +15,10 @@ head([
 
 <p class="content-online"><a href='../version-history'>Version history</a></p>
 
-<!-- Content below this copied into the Keyman Android info.html -->
+<!-- The 'tab header' will eventually have class="content-online"
+     since an embedding device can specify which version to use.
 
+     The Android app needs to add this functionality first, though. -->
 <div id="android-tab-header">
   <div id="android-mobile-header">
     <h4>Phone</h4>
@@ -26,7 +28,7 @@ head([
   </div>
 </div>
 
-<div class="tab" id="android-mobile-tab">
+<div>
   <p>
     Keyman for Android lets you type in over 600 languages on Android mobiles and tablets.
     To get started, here are some helpful hints:
@@ -36,29 +38,47 @@ head([
       <th colspan="2">Keyboard Keys <br/>(Keyboard Present)</th>
     </tr>
     <tr>
-      <td><img id="install-keyboard-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/></td>
+      <td>
+        <img class="phone" id="install-keyboard-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/>
+        <img class="tablet" id="install-keyboard-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/>
+      </td>
       <td>Select another language/keyboard</td>
     </tr>
     <tr>
-      <td><img id="hide-keyboard-ap" src="<?php echo cdn("img/app/12.0/hide-keyboard-ap.png"); ?>"/></td>
+      <td>
+        <img class="phone" id="hide-keyboard-ap" src="<?php echo cdn("img/app/12.0/hide-keyboard-ap.png"); ?>"/>
+        <img class="tablet" id="hide-keyboard-at" src="<?php echo cdn("img/app/12.0/hide-keyboard-at.png"); ?>"/>
+      </td>
       <td>Hide the keyboard</td>
     </tr>
     <tr>
-      <td><img id="backspace-ap" src="<?php echo cdn("img/app/12.0/backspace-ap.png"); ?>"/></td>
+      <td>
+        <img class="phone" id="backspace-ap" src="<?php echo cdn("img/app/12.0/backspace-ap.png"); ?>"/>
+        <img class="tablet" id="backspace-at" src="<?php echo cdn("img/app/12.0/backspace-at.png"); ?>"/>
+      </td>
       <td>Backspace</td>
     </tr>
     <tr>
-      <td><img id="return-ap" src="<?php echo cdn("img/app/12.0/return-ap.png"); ?>"/></td>
+      <td>
+        <img class="phone" id="return-ap" src="<?php echo cdn("img/app/12.0/return-ap.png"); ?>"/>
+        <img class="tablet" id="return-at" src="<?php echo cdn("img/app/12.0/return-at.png"); ?>"/>
+      </td>
       <td>Return</td>
     </tr>
     <tr>
-      <td><img id="shift-ap" src="<?php echo cdn("img/app/12.0/shift-ap.png"); ?>"/></td>
+      <td>
+        <img class="phone" id="shift-ap" src="<?php echo cdn("img/app/12.0/shift-ap.png"); ?>"/>
+        <img class="tablet" id="shift-at" src="<?php echo cdn("img/app/12.0/shift-at.png"); ?>"/>
+      </td>
       <td>Shift key. Long press this key to access the CTRL, ALT and CTRL ALT keys
         (which can access additional key layers)
       </td>
     </tr>
     <tr>
-      <td><img id="touch-hold-ap" src="<?php echo cdn("img/app/12.0/touch-hold-ap.png"); ?>"/></td>
+      <td>
+        <img class="phone" id="touch-hold-ap" src="<?php echo cdn("img/app/12.0/touch-hold-ap.png"); ?>"/>
+        <img class="tablet" id="touch-hold-at" src="<?php echo cdn("img/app/12.0/touch-hold-at.png"); ?>"/>
+      </td>
       <td>Keys with a small dot in the top right corner indicate a long press key. Access
         further functionality by long pressing the key
       </td>
@@ -108,7 +128,8 @@ head([
     <br/>
     With the keyboard visible, touch the globe key:
     <br/>
-    <img id="globe-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/>
+    <img class="phone" id="globe-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/>
+    <img class="tablet" id="globe-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/>
     <br/>
     This will bring up a list of all currently installed languages (the default is English
     EuroLatin (SIL)). If you have already downloaded additional languages, they will appear here.
@@ -133,7 +154,7 @@ head([
     From the 'Installed languages' menu, touch the <span class="command">+</span>
     button in the bottom right corner of your screen.
     <br/>
-    <img id="plus-ap" src="<?php echo cdn("img/app/12.0/plus-a.png"); ?>" />
+    <img id="plus-a" src="<?php echo cdn("img/app/12.0/plus-a.png"); ?>" />
     <br/><br/>
     Step 4)
     <br/>
@@ -141,26 +162,29 @@ head([
     the language you want to install. Languages marked with a right arrow have multiple keyboards - for
     example we have 10+ different Tamil keyboards.
     <br/>
-    <img id="lang-list-ap" src="<?php echo cdn("img/app/12.0/lang-list-ap.png"); ?>"/>
+    <img class="phone" id="lang-list-ap" src="<?php echo cdn("img/app/12.0/lang-list-ap.png"); ?>"/>
+    <img class="tablet" id="lang-list-at" src="<?php echo cdn("img/app/12.0/lang-list-at.png"); ?>"/>
     <br/><br/>
     Select the language and keyboard you want to install - a popup will ask for confirmation,
     hit the <span class="command">Download</span> button.
     <br/>
-    <img id="confirm-dl-ap" src="<?php echo cdn("img/app/12.0/confirm-dl-ap.png"); ?>"/>
+    <img class="phone" id="confirm-dl-ap" src="<?php echo cdn("img/app/12.0/confirm-dl-ap.png"); ?>"/>
+    <img class="tablet" id="confirm-dl-at" src="<?php echo cdn("img/app/12.0/confirm-dl-at.png"); ?>"/>
     <br/><br/>
     Step 5)
     <br/>
     Once the download is complete, the new keyboard will be selected. Touch the <span class="command">&larr;</span>
     button on the top left corner of the popup several times and the new keyboard will become active.
     <br/>
-    <img id="success-ap" src="<?php echo cdn("img/app/12.0/dl-success-ap.png"); ?>"/>
+    <img class="phone" id="success-ap" src="<?php echo cdn("img/app/12.0/dl-success-ap.png"); ?>"/>
+    <img class="tablet" id="success-at" src="<?php echo cdn("img/app/12.0/dl-success-at.png"); ?>"/>
     <br/><br/>
     Alternate Step for System Keyboard)
     <br/>
     The Keyman system keyboard has an additional <span class="command">CLOSE KEYMAN</span> button at the bottom left of
     the "Keyboards" menu. Pushing this button will close Keyman and switch to the next non-Keyman system keyboard.
     <br/>
-    <img id="close-keyman-ap" src="<?php echo cdn("img/app/12.0/close-keyman-a.png"); ?> "/>
+    <img id="close-keyman-a" src="<?php echo cdn("img/app/12.0/close-keyman-a.png"); ?> "/>
     <br/>
   </p>
 
@@ -204,7 +228,8 @@ head([
     <br/>
     You'll see a notification when the keyboard is deleted.
     <br/>
-    <img id="uninstall-notification-ap" src="<?php echo cdn("img/app/12.0/uninstall-notification-ap.png"); ?>"/>
+    <img class="phone" id="uninstall-notification-ap" src="<?php echo cdn("img/app/12.0/uninstall-notification-ap.png"); ?>"/>
+    <img class="tablet" id="uninstall-notification-at" src="<?php echo cdn("img/app/12.0/uninstall-notification-at.png"); ?>"/>
   </p>
 
   <h2>Hotkey</h2>
@@ -218,7 +243,10 @@ head([
   <p>
     Step 1) Open the keyboard list by touching the globe key.
   </p>
-  <p><img id="keyboard-help1-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/></p>
+  <p>
+    <img class="phone" id="keyboard-help1-ap" src="<?php echo cdn("img/app/12.0/globe-ap.png"); ?>"/>
+    <img class="tablet" id="keyboard-help1-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/>
+  </p>
   <br/>
   <p>
     Step 2) Touch the info icon for your keyboard.
@@ -231,43 +259,67 @@ head([
     Step 1) Open the Keyman app and select the menu for additional options.
     The screenshots below are of a device running Android 9.0 Pie.
   </p>
-  <p><img id="settings1-ap" src="<?php echo cdn("img/app/12.0/settings1-ap.png"); ?>"/></p>
+  <p>
+    <img class="phone" id="settings1-ap" src="<?php echo cdn("img/app/12.0/settings1-ap.png"); ?>"/>
+    <img class="tablet" id="settings1-at" src="<?php echo cdn("img/app/12.0/settings1-at.png"); ?>"/>
+  </p>
   <br/>
   <p>
     Step 2) Select 'Get Started' and then select 'Enable Keyman as system-wide keyboard'.
   </p>
-  <p><img id="settings2-ap" src="<?php echo cdn("img/app/12.0/settings2-ap.png"); ?>"/></p>
+  <p>
+    <img class="phone" id="settings2-ap" src="<?php echo cdn("img/app/12.0/settings2-ap.png"); ?>"/>
+    <img class="tablet" id="settings2-at" src="<?php echo cdn("img/app/12.0/settings2-at.png"); ?>"/>
+  </p>
   <br/>
   <p>
     This will open an Android settings screen for 'Available virtual keyboard'.
   </p>
-  <p><img id="settings3-ap" src="<?php echo cdn("img/app/12.0/settings3-ap.png"); ?>"/></p>
+  <p>
+    <img class="phone" id="settings3-ap" src="<?php echo cdn("img/app/12.0/settings3-ap.png"); ?>"/>
+    <img class="tablet" id="settings3-at" src="<?php echo cdn("img/app/12.0/settings3-at.png"); ?>"/>
+  </p>
   <br/>
   <p>
     Step 3) Enable 'Keyman' as an available virtual keyboard.
     This will bring up two confirmation dialogs.
   </p>
-  <p><img id="settings4-ap" src="<?php echo cdn("img/app/12.0/settings4-ap.png"); ?>"/></p>
+  <p>
+    <img class="phone" id="settings4-ap" src="<?php echo cdn("img/app/12.0/settings4-ap.png"); ?>"/>
+    <img class="tablet" id="settings4-at" src="<?php echo cdn("img/app/12.0/settings4-at.png"); ?>"/>
+  </p>
   <br/>
-  <p><img id="settings5-ap" src="<?php echo cdn("img/app/12.0/settings5-ap.png"); ?>"/></p>
+  <p>
+    <img class="phone" id="settings5-ap" src="<?php echo cdn("img/app/12.0/settings5-ap.png"); ?>"/>
+    <img class="tablet" id="settings5-at" src="<?php echo cdn("img/app/12.0/settings5-at.png"); ?>"/>
+  </p>
   <br/>
   <p>
     Select 'OK' on both. Now when the on-screen keyboard appears for apps other than Keyman,
     you'll see a keyboard icon at the bottom right.
   </p>
-  <p><img id="settings6-ap" src="<?php echo cdn("img/app/12.0/settings6-ap.png"); ?>"/></p>
+  <p>
+    <img class="phone" id="settings6-ap" src="<?php echo cdn("img/app/12.0/settings6-ap.png"); ?>"/>
+    <img class="tablet" id="settings6-at" src="<?php echo cdn("img/app/12.0/settings6-at.png"); ?>"/>
+  </p>
   <br/>
   <p>
     Click the keyboard icon whenever you want to change the current system keyboard.
   </p>
-  <p><img id="settings7-ap" src="<?php echo cdn("img/app/12.0/settings7-ap.png"); ?>"/></p>
+  <p>
+    <img class="phone" id="settings7-ap" src="<?php echo cdn("img/app/12.0/settings7-ap.png"); ?>"/>
+    <img class="tablet" id="settings7-at" src="<?php echo cdn("img/app/12.0/settings7-at.png"); ?>"/>
+  </p>
   <br/><br/>
 
   <h2>Installing Custom Keyboards</h2>
   <p>
     Step 1) Click the link to your custom keyboard package file. The link in this example is for Khmer Angkor keyboard.
   </p>
-  <p><img id="dist-url-screen-ap" src="<?= cdn('img/app/12.0/dist-url-screen-ap.png')?>"></p>
+  <p>
+    <img class="phone" id="dist-url-screen-ap" src="<?= cdn('img/app/12.0/dist-url-screen-ap.png')?>">
+    <img class="tablet" id="dist-url-screen-at" src="<?= cdn('img/app/12.0/dist-url-screen-at.png')?>">
+  </p>
   <p>
     Step 2) Once the KMP file is on your device, you will need to browse to the KMP file and select it.
     From the Keyman menu, select 'Settings'.
@@ -279,7 +331,10 @@ head([
     The device will launch a file browser where you'll browse to the directory of your KMP file.
     A common place to look is the "Downloads" folder.
   </p>
-  <p><img id="dist-file-browser-ap" src="<?= cdn('img/app/12.0/dist-file-browser-ap.png')?>"></p>
+  <p>
+    <img class="phone" id="dist-file-browser-ap" src="<?= cdn('img/app/12.0/dist-file-browser-ap.png')?>">
+    <img class="tablet" id="dist-file-browser-at" src="<?= cdn('img/app/12.0/dist-file-browser-at.png')?>">
+  </p>
   <p>
     Selecting the KMP file should bring you to Step 3)
   </p>
@@ -288,7 +343,10 @@ head([
     for Android needs access to read storage for installing the KMP file. At the dialog, select "ALLOW". Once authorized,
     Keyman for Android won't need to ask for storage permission again, unless the user revokes or uninstalls the app.
   </p>
-  <p><img id="dist-storrage-permission-ap" src="<?php echo cdn("img/app/12.0/dist-storage-permission-ap.png"); ?>"/></p>
+  <p>
+    <img class="phone" id="dist-storrage-permission-ap" src="<?php echo cdn("img/app/12.0/dist-storage-permission-ap.png"); ?>"/>
+    <img class="tablet" id="dist-storrage-permission-at" src="<?php echo cdn("img/app/12.0/dist-storage-permission-at.png"); ?>"/>
+  </p>
   <p>
     Older versions of Android grant Storage permissions at app installation time, so those users can skip this step.
   </p>
@@ -296,7 +354,10 @@ head([
     Step 4) Keyman for Android will parse the metadata in the package. If the keyboard package includes a "welcome.htm"
     file, this will be displayed at the confirmation to install the keyboard package.
   </p>
-  <p><img id="dist-welcome-ap" src="<?php echo cdn("img/app/12.0/dist-welcome-ap.png"); ?>"/></p>
+  <p>
+    <img class="phone" id="dist-welcome-ap" src="<?php echo cdn("img/app/12.0/dist-welcome-ap.png"); ?>"/>
+    <img class="tablet" id="dist-welcome-at" src="<?php echo cdn("img/app/12.0/dist-welcome-at.png"); ?>"/>
+  </p>
   <p>
     If "welcome.htm" is not included, a generic page with the package ID and package version will be shown. Click the
     left "Install" button to install the entire keyboard package.
@@ -305,7 +366,10 @@ head([
     Step 5) All the keyboards in the package are installed as a group. In this example, the package only has the
     "Khmer Angkor" keyboard, so it becomes the active keyboard.
   </p>
-  <p><img id="dist-install1-ap" src="<?php echo cdn("img/app/12.0/dist-install1-ap.png"); ?>"/></p>
+  <p>
+    <img class="phone" id="dist-install1-ap" src="<?php echo cdn("img/app/12.0/dist-install1-ap.png"); ?>"/>
+    <img class="tablet" id="dist-install1-at" src="<?php echo cdn("img/app/12.0/dist-install1-at.png"); ?>"/>
+  </p>
   <p>
     Once the keyboard has been downloaded, you should be able to use it as normal.
     <br/>
@@ -324,340 +388,10 @@ head([
     Step 2) Depending on your device, click "Apps", "Apps &amp; notifications", or "App permissions" and grant Keyman
     storage permission. The screenshot below is from Android 9.0 Pie.
   </p>
-  <p><img id="keyman-storage-permission-ap" src="<?php echo cdn("img/app/12.0/keyman-storage-permission-ap.png"); ?>"/></p>
-
-  <h2>Use the Keyman Browser</h2>
   <p>
-    Step 1) Click the Keyman Browser button in the Keyman app
-    <br/>
-    Step 2) Enter the URL of a website to visit into the address bar, for example <strong>google.com</strong>.
-    Keyman Browser will load the page and detect your language if it is present, and reformat it to show your
-    language instead of square boxes.
-    <br/>
-    Step 3) Use the bookmark button to save the current page for browsing later.
-    <br/>
-    Step 4) Use the Globe icon to swap between languages.
+    <img class="phone" id="keyman-storage-permission-ap" src="<?php echo cdn("img/app/12.0/keyman-storage-permission-ap.png"); ?>"/>
+    <img class="tablet" id="keyman-storage-permission-at" src="<?php echo cdn("img/app/12.0/keyman-storage-permission-at.png"); ?>"/>
   </p>
-
-  <h2>Integrate Keyman with your App or Website</h2>
-  <p>
-    If you are interested in learning how Keyman can be integrated into your own app or
-    website, visit <a href="https://keyman.com/engine/">keyman.com/engine</a>
-  </p>
-
-  <h2>Further Help</h2>
-  <p>
-    For more information on Keyman, visit <a href="https://keyman.com">keyman.com</a>
-    <br/><br/>
-    For more information on Keyman for Android, visit <a href="https://keyman.com/android">keyman.com/android</a>
-  </p>
-
-  <div class="content-online">
-    <h2>Keyman for Android Documentation Versions</h2>
-
-    <ul>
-      <li><a href='../12.0/'>Keyman for Android 12.0 Documentation</a></li>
-      <li><a href='../11.0/'>Keyman for Android 11.0 Documentation</a></li>
-      <li><a href='../10.0/'>Keyman for Android 10.0 Documentation</a></li>
-      <li><a href='../2.0/'>Keyman for Android 2.0 Documentation</a></li>
-    </ul>
-  </div>
-</div>
-
-<div class="tab selected-tab" id="android-tablet-tab">
-  <p>
-    Keyman for Android lets you type in over 600 languages on Android mobiles and tablets.
-    To get started, here are some helpful hints:
-  </p>
-  <table>
-    <tr>
-      <th colspan="2">Keyboard Keys <br/>(Keyboard Present)</th>
-    </tr>
-    <tr>
-      <td><img id="install-keyboard-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/></td>
-      <td>Select another language/keyboard</td>
-    </tr>
-    <tr>
-      <td><img id="hide-keyboard-at" src="<?php echo cdn("img/app/12.0/hide-keyboard-at.png"); ?>"/></td>
-      <td>Hide the keyboard</td>
-    </tr>
-    <tr>
-      <td><img id="backspace-at" src="<?php echo cdn("img/app/12.0/backspace-at.png"); ?>"/></td>
-      <td>Backspace</td>
-    </tr>
-    <tr>
-      <td><img id="return-at" src="<?php echo cdn("img/app/12.0/return-at.png"); ?>"/></td>
-      <td>Return</td>
-    </tr>
-    <tr>
-      <td><img id="shift-at" src="<?php echo cdn("img/app/12.0/shift-at.png"); ?>"/></td>
-      <td>Shift key. Long press this key to access the CTRL, ALT and CTRL ALT keys
-        (which can access additional key layers)
-      </td>
-    </tr>
-    <tr>
-      <td><img id="touch-hold-at" src="<?php echo cdn("img/app/12.0/touch-hold-at.png"); ?>"/></td>
-      <td>Keys with a small dot in the top right corner indicate a long press key. Access
-        further functionality by long pressing the key
-      </td>
-    </tr>
-    <tr>
-      <th colspan="2" id="toolbar-at">Toolbar Icons</th>
-    </tr>
-    <tr>
-      <td><img id="share-at" src="<?php echo cdn("img/app/12.0/share-a.png"); ?>"/></td>
-      <td>Share your text via Mail, Text, or Twitter</td>
-    </tr>
-    <tr>
-      <td><img id="browser-at" src="<?php echo cdn("img/app/12.0/browser-a.png"); ?>"/></td>
-      <td>Open the Keyman Browser to use the web in your language</td>
-    </tr>
-    <tr>
-      <td><img id="font-size-at" src="<?php echo cdn("img/app/12.0/font-size-a.png"); ?>"/></td>
-      <td>Adjust the font size</td>
-    </tr>
-    <tr>
-      <td><img id="delete-at" src="<?php echo cdn("img/app/12.0/delete-a.png"); ?>"/></td>
-      <td>Delete all current text</td>
-    </tr>
-    <tr>
-      <td><img id="info-at" src="<?php echo cdn("img/app/12.0/info-a.png"); ?>"/></td>
-      <td>Load this help page</td>
-    </tr>
-    <tr>
-      <td><img id="get-started-at" src="<?php echo cdn("img/app/12.0/get-started-a.png"); ?>"/></td>
-      <td>Open the initial setup screen</td>
-    </tr>
-    <tr>
-      <td><img id="settings-at" src="<?php echo cdn("img/app/12.0/settings-a.png"); ?>"/></td>
-      <td>Open the Keyman Settings screen</td>
-    </tr>
-  </table>
-
-  <h2>Switching between Keyboards</h2>
-  <p>
-    To switch keyboards, follow these steps:
-    <br/><br/>
-    Step 1)
-    <br/>
-    With the keyboard visible, touch the globe key:
-    <br/>
-    <img id="globe-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/>
-    <br/>
-    This will bring up a list of all currently installed languages (the default is English
-    EuroLatin (SIL)). If you have already downloaded additional languages, they will appear here.
-    Simply select them and the keyboard will re-appear with the new language.
-    <br/><br/>
-
-  <h2>Adding New Keyboards</h2>
-  <p>
-    To add keyboards, follow these steps:
-    <br/><br/>
-    Step 1)
-    <br/>
-    Open the menu for additional options. Select 'Settings'
-    <br/><br/>
-    Step 2)
-    <br/>
-    From the Keyman Settings menu, select 'Installed languages'
-    <br/>
-    <img id="settings-language-at" src="<?php echo cdn("img/app/12.0/settings-language-ap.png"); ?>" />
-    <br/><br/>
-    Step 3)
-    From the 'Installed languages' menu, touch the <span class="command">+</span>
-    button in the bottom right corner of your screen.
-    <br/>
-    <img id="plus-at" src="<?php echo cdn("img/app/12.0/plus-a.png"); ?>" />
-    <br/><br/>
-    Step 4)
-    <br/>
-    A list of all available languages will appear. Scroll through this list until you find
-    the language you want to install. Languages marked with a right arrow have multiple keyboards - for
-    example we have 10+ different Tamil keyboards.
-    <br/>
-    <img id="lang-list-at" src="<?php echo cdn("img/app/12.0/lang-list-at.png"); ?>"/>
-    <br/><br/>
-    Select the language and keyboard you want to install - a popup will ask for confirmation,
-    hit the <span class="command">Download</span> button.
-    <br/>
-    <img id="confirm-dl-at" src="<?php echo cdn("img/app/12.0/confirm-dl-at.png"); ?>"/>
-    <br/><br/>
-    Step 5)
-    <br/>
-    Once the download is complete, the new keyboard will be selected. Touch the <span class="command">&larr;</span>
-    button on the top left corner of the popup several times and the new keyboard will become active.
-    <br/>
-    <img id="success-at" src="<?php echo cdn("img/app/12.0/dl-success-at.png"); ?>"/>
-    <br/><br/>
-    Alternate Step for System Keyboard)
-    <br/>
-    The Keyman system keyboard has an additional <span class="command">CLOSE KEYMAN</span> button at the bottom left of
-    the "Keyboards" menu. Pushing this button will close Keyman and switch to the next non-Keyman system keyboard.
-    <br/>
-    <img id="close-keyman-at" src="<?php echo cdn("img/app/12.0/close-keyman-a.png"); ?> "/>
-    <br/>
-  </p>
-
-  <h2>Removing a Keyboard</h2>
-  <p>
-    To uninstall a keyboard, follow these steps:
-    <br/><br/>
-    Step 1)
-    <br/>
-    From the menu, select 'Settings'
-    <br/><br/>
-    Step 2)
-    <br/>
-    From the Keyman Settings menu, select 'Installed languages'
-    <br/>
-    <img id="settings-languages-at" src="<?php echo cdn("img/app/12.0/settings-languages-ap.png"); ?>"/>
-    <br/><br/>
-    Step 3)
-    From the 'Installed languages' menu, select the language for the keyboard you want to remove.
-    <br/>
-    <img id="settings-two-installed-languages-at" src="<?php echo cdn("img/app/12.0/settings-two-installed-languages-ap.png"); ?>" />
-    <br/><br/>
-    Step 4) The language Settings menu lists currently installed keyboards associated with the language.
-    Select the keyboard you want to uninstall
-    <br/>
-    <img id="khmer-settings-at" src="<?php echo cdn("img/app/12.0/khmer-settings-ap.png"); ?>" />
-    <br/><br/>
-    Step 5)
-    <br/>
-    The bottom of the keyboard settings menu displays an option to uninstall the keyboard.
-    Select 'Uninstall keyboard' to get a prompt to delete the keyboard.
-    <br/>
-    Note: the default 'SIL EuroLatin' keyboard for English cannot be removed.
-    <br/>
-    <img id="settings-khmer-info-at" src="<?php echo cdn("img/app/12.0/settings-khmer-info-ap.png"); ?>"/>
-    <br/><br/>
-    Step 6)
-    Press "Delete" to uninstall the keyboard.
-    <br/>
-    <img id="confirm-khmer-delete-at" src="<?php echo cdn("img/app/12.0/confirm-khmer-delete-ap.png"); ?>"/>
-    <br/>
-    You'll see a notification when the keyboard is deleted.
-    <br/>
-    <img id="uninstall-notification-at" src="<?php echo cdn("img/app/12.0/uninstall-notification-at.png"); ?>"/>
-  </p>
-
-  <h2>Hotkey</h2>
-  <p>
-    To switch between languages while using an external keyboard (i.e. a bluetooth keyboard), a quick and easy way is to
-    use a hotkey combination. Press and hold 'Ctrl' and then press 'Tab'.
-    You should see a list of languages/keyboards. Tap on any available language of your choice.
-  </p>
-
-  <h2>Accessing Keyboard Help</h2>
-  <p>
-    Step 1) Open the keyboard list by touching the globe key.
-  </p>
-  <p><img id="keyboard-help1-at" src="<?php echo cdn("img/app/12.0/globe-at.png"); ?>"/></p>
-  <br/>
-  <p>
-    Step 2) Touch the info icon for your keyboard.
-  </p>
-  <p><img id="keyboard-help2-at" src="<?php echo cdn("img/app/12.0/info-a-gray.png"); ?>"/></p>
-  <br/>
-
-  <h2>Installing System Wide Keyboards</h2>
-  <p>
-    Step 1) Open the Keyman app. The screenshots below are of a device running Android 8.1 Oreo.
-  </p>
-  <p><img id="settings1-at" src="<?php echo cdn("img/app/12.0/settings1-at.png"); ?>"/></p>
-  <br/>
-  <p>
-    Step 2) Select 'Get Started' and then select 'Enable Keyman as system-wide keyboard'.
-  </p>
-  <p><img id="settings2-at" src="<?php echo cdn("img/app/12.0/settings2-at.png"); ?>"/></p>
-  <br/>
-  <p>
-    This will open an Android settings screen for 'Available virtual keyboard'.
-  </p>
-  <p><img id="settings3-at" src="<?php echo cdn("img/app/12.0/settings3-at.png"); ?>"/></p>
-  <br/>
-  <p>
-    Step 3) Enable 'Keyman' as an available virtual keyboard.
-    This will bring up two confirmation dialogs.
-  </p>
-  <p><img id="settings4-at" src="<?php echo cdn("img/app/12.0/settings4-at.png"); ?>"/></p>
-  <br/>
-  <p><img id="settings5-at" src="<?php echo cdn("img/app/12.0/settings5-at.png"); ?>"/></p>
-  <br/>
-  <p>
-    Select 'OK' on both. Now when the on-screen keyboard appears for apps other than Keyman,
-    you'll see a keyboard icon at the bottom right.
-  </p>
-  <p><img id="settings6-at" src="<?php echo cdn("img/app/12.0/settings6-at.png"); ?>"/></p>
-  <br/>
-  <p>
-    Click the keyboard icon whenever you want to change the current system keyboard.
-  </p>
-  <p><img id="settings7-at" src="<?php echo cdn("img/app/12.0/settings7-at.png"); ?>" /></p>
-  <br/><br/>
-
-  <h2>Installing Custom Keyboards</h2>
-  <p>
-    Step 1) Click the link to your custom keyboard package file. The link in this example is for Khmer Angkor keyboard.
-  </p>
-  <p><img id="dist-url-screen-at" src="<?= cdn('img/app/12.0/dist-url-screen-at.png')?>"></p>
-  <p>
-    Step 2) Once the KMP file is on your device, you will need to browse to the KMP file and select it.
-    From the Keyman menu, select 'Settings'.
-    <br/>
-    From the Keyman Settings menu, select 'Add Keyboard from Device'.
-  </p>
-  <p><img id="settings-add-keyboard-from-device-at" src="<?php echo cdn("img/app/12.0/settings-language-ap.png"); ?>" /></p>
-  <p>
-    The device will launch a file browser where you'll browse to the directory of your KMP file.
-    A common place to look is the "Downloads" folder.
-  </p>
-  <p><img id="dist-file-browser-at" src="<?= cdn('img/app/12.0/dist-file-browser-at.png')?>"></p>
-  <p>
-    Selecting the KMP file should bring you to Step 3)
-  </p>
-  <p>
-    Step 3) On Android 6.0 (Marshmallow) and higher, mobile apps need to request permissions to access storage. Keyman
-    for Android needs access to read storage for installing the KMP file. At the dialog, select "ALLOW". Once authorized,
-    Keyman for Android won't need to ask for storage permission again, unless the user revokes or uninstalls the app.
-  </p>
-  <p><img id="dist-storage-permission-at" src="<?php echo cdn("img/app/12.0/dist-storage-permission-at.png"); ?>"/></p>
-  <p>
-    Older versions of Android grant Storage permissions at app installation time, so those users can skip this step.
-  </p>
-  <p>
-    Step 4) Keyman for Android will parse the metadata in the package. If the keyboard package includes a "welcome.htm"
-    file, this will be displayed at the confirmation to install the keyboard package.
-  </p>
-  <p><img id="dist-welcome-at" src="<?php echo cdn("img/app/12.0/dist-welcome-at.png"); ?>"/></p>
-  <p>
-    If "welcome.htm" is not included, a generic page with the package ID and package version will be shown. Click the
-    left "Install" button to install the entire keyboard package.
-  </p>
-  <p>
-    Step 5) All the keyboards in the package are installed as a group. In this example, the package only has the
-    "Khmer Angkor" keyboard, so it becomes the active keyboard.
-  </p>
-  <p><img id="dist-install1-at" src="<?php echo cdn("img/app/12.0/dist-install1-at.png"); ?>"/></p>
-  <p>
-    Once the keyboard has been downloaded, you should be able to use it as normal.
-    <br/>
-    To learn how to create a custom installable keyboard,
-    <a href="https://help.keyman.com/developer/12.0/guides/distribute/">click here</a>.
-  </p>
-
-  <h2>Granting storage permission</h2>
-  <p>
-    If Keyman for Android is permanently denied storage access, attempts to install custom keyboards will fail with the
-    notification "Storage permission request was denied". Perform these steps to grant Keyman for Android access to storage
-  </p>
-  <p>
-    Step 1) Go to Android Settings.
-    <br/>
-    Step 2) Depending on your device, click "Apps", "Apps &amp; notifications", or "App permissions" and grant Keyman
-    storage permission. The screenshot below is from Android 8.1 Oreo.
-  </p>
-  <p><img id="keyman-storage-permission-at" src="<?php echo cdn("img/app/12.0/keyman-storage-permission-at.png"); ?>"/></p>
 
   <h2>Use the Keyman Browser</h2>
   <p>


### PR DESCRIPTION
Before going further with the Android help page (by splitting it into multiple smaller pages), I felt it wise to focus on a simple redo of the existing page using CSS tricks.  Rather than maintain two separate tabs and performing wholesale "display: none" vs "display: block" operations, this uses CSS to toggle which image is displayed on the page in line with the surrounding text.

In all, this allows us to write the documentation on the page itself just the once, though of course there is all the PHP for image source links.

Note that this does temporarily break the ability to easily offline-mirror the page, but I've got a script near ready to handle that side of things (similar to the one introduced in https://github.com/keymanapp/keyman/pull/2102).

I'm still working on getting the Android app to produce the appropriate 'formFactor' query parameter for use with the page, but I can already see the path forward for it, both for online and offline modes.  In the meantime, the page still supports the old tab-button menu for phone vs tablet images, and their use will set `$_SESSION` accordingly.  Not that it's of use with any other pages _yet_, but it will be.

And, uh, please ignore the description of the second commit.  Kinda got it inverted there.  Third commit is mostly whitespace, so a good ol' `?w=1` may help.