### PR TITLE
Android help:  Re-enables non-embedded CSS autodetect

### DIFF
--- a/_includes/includes/template.php
+++ b/_includes/includes/template.php
@@ -152,6 +152,8 @@
   
   function begin_main($toc, $index, $crumbs, $embeddable, $do_embed){
     global $index_content;
+    global $formFactor;
+
     if($index) {
       build_index_content();
     } else {
@@ -170,6 +172,16 @@
 
     if($toc) { $tocClass = ''; } else { $tocClass = ' no-toc'; }
     if(!$index) { $tocClass .= ' no-index'; }
+    if(isset($formFactor)) {
+      if($formFactor == 'detect') {
+        ?>
+        <script type="text/javascript">
+          // Will be used in kmlive.js.
+          window['km_detectFormFactor'] = true;
+        </script>
+        <?php
+      }
+    }
 
     $outerClass = build_page_class($embeddable, $do_embed);
     if(!empty($outerClass)) {

--- a/cdn/dev/js/kmlive.js
+++ b/cdn/dev/js/kmlive.js
@@ -76,6 +76,13 @@ function loaded(){
     }
   }
 
+  // detectFormFactor defined in template.php based upon use of session-formfactor.php.
+  if ($(window).width() <= 600 && window['km_detectFormFactor']) {
+    var section2 = $('#section2');
+    section2.removeClass('tablet-form');
+    section2.addClass('phone-form');
+  }
+
   /*!
    * toc - jQuery Table of Contents Plugin
    * v0.3.2


### PR DESCRIPTION
This PR's base (#51) temporarily disabled kmlive's form-factor autodetection given some of the changes to CSS.  This PR patches that (since #51's already approved) to re-enable it, but only when form-factor isn't specified by query.

This restores the default online auto-detect behavior of the page while still allowing the user to persistently set the form-factor if desired once the page is split into multiples. 