### PR TITLE
Basic keymanweb.com product page

### DIFF
--- a/products/web/12.0/index.php
+++ b/products/web/12.0/index.php
@@ -20,7 +20,7 @@
   Bookmarklet for your browser.
 </p>
 
-<p><a href='http://keymanweb.com'>Visit Keymanweb.com now</a></p>
-<a href='http://keymanweb.com'><img class="center" src="<?php echo cdn('img/kmw_screenshot.png'); ?>" /></a>
+<p><a href='https://keymanweb.com'>Visit Keymanweb.com now</a></p>
+<a href='https://keymanweb.com'><img class="center" src="<?php echo cdn('img/kmw_screenshot.png'); ?>" /></a>
 
 </div>

--- a/products/web/12.0/index.php
+++ b/products/web/12.0/index.php
@@ -1,0 +1,26 @@
+<?php
+  require_once('includes/template.php');
+  
+  head([
+    'title' => 'keymanweb.com Support'
+  ]);
+?>  
+
+<div class='body_text'>
+
+<p style='margin-top: 16px'>
+  The Keymanweb.com applications provides a working examples of how Keyman Engine for Web may be integrated to provide
+  various functions on a range of websites.
+</p>
+<p>
+  You can use Keymanweb.com to type in any of our available languages, and then post your message to Twitter,
+  as well as search Google or copy it to your clip board.
+  <br/><br/>
+  Keymanweb.com also provides links to download the active keyboard with Keyman Desktop, or install it as a
+  Bookmarklet for your browser.
+</p>
+
+<p><a href='http://keymanweb.com'>Visit Keymanweb.com now</a></p>
+<a href='http://keymanweb.com'><img class="center" src="<?php echo cdn('img/kmw_screenshot.png'); ?>" /></a>
+
+</div>


### PR DESCRIPTION
While the 11.0 section has more content, said content is a duplicate of the also-deprecated web/_`<`version`>`_/ui content - there's no reason to maintain it twice.  This leaves the Products > keymanweb.com section with a pretty small amount of content, but that's probably fine.