### PR TITLE
Update primary links to 12.0

### DIFF
--- a/_includes/includes/phone-menu.php
+++ b/_includes/includes/phone-menu.php
@@ -47,7 +47,7 @@
             <h3>Developer Support</h3>
             <ul>
              <li><a href="/developer">Developer Home</a></li>
-                <li><a href="/developer/10.0">Keyman Developer</a></li>
+                <li><a href="/developer/12.0">Keyman Developer</a></li>
                 <li><a href="/developer/engine/web">Keyman Engine for Web</a></li>
                 <li><a href="/developer/engine/iphone-and-ipad/">Keyman Engine for iPhone and iPad</a></li>
                 <li><a href="/developer/engine/android/">Keyman Engine for Android</a></li>

--- a/_includes/includes/top-menu.php
+++ b/_includes/includes/top-menu.php
@@ -36,7 +36,7 @@
                 <div class="menu-item-dropdown">
                     <div class="menu-dropdown-inner">
                         <ul>
-                            <li><a href="/developer/10.0/">Keyman Developer</a></li>
+                            <li><a href="/developer/12.0/">Keyman Developer</a></li>
                             <li><a href="/developer/language/">Keyman Keyboard Language</a></li>
                             <li><a href="/developer/engine/web/">Keyman Engine for Web</a></li>
                             <li><a href="/developer/engine/iphone-and-ipad/">Keyman Engine for iOS</a></li>

--- a/developer/engine/android/web.config
+++ b/developer/engine/android/web.config
@@ -3,12 +3,12 @@
     <system.webServer>
         <rewrite>
             <rules>
-                <rule name="Redirect unversioned paths to 11.0/ path">
+                <rule name="Redirect unversioned paths to 12.0/ path">
                     <match url="(.*)" />
                     <conditions>
                         <add input="{URL}" pattern="(2|10|11|12)\.0(\/)?" negate="true" />
                     </conditions>
-                    <action type="Redirect" url="11.0/{R:1}" />
+                    <action type="Redirect" url="12.0/{R:1}" />
                 </rule>
             </rules>
         </rewrite>

--- a/developer/engine/desktop/10.0/api/index.php
+++ b/developer/engine/desktop/10.0/api/index.php
@@ -12,6 +12,7 @@
 <h2>Introduction</h2>
 
 <p>The Keyman Engine for Windows 10.0 API is implemented in COM. It can be instantiated with <code>CreateObject("keymanapi.Keyman")</code>.</p>
+<aside><b>Note: </b>This documentation applies to Keyman Engine for Desktop versions 10.0 to 12.0</aside>
 
 <h2>Interface Hierarchy</h2>
 

--- a/developer/engine/desktop/10.0/index.php
+++ b/developer/engine/desktop/10.0/index.php
@@ -8,6 +8,7 @@ head([
 <h1 class="title">Keyman Engine for Desktop 10.0</h1>
 
 <p>Keyman Engine for Desktop 10.0 gives you the tools to build a customised desktop keyboarding product for Windows.</p>
+<aside><b>Note: </b>This documentation applies to Keyman Engine for Desktop versions 10.0 to 12.0</aside>
 
 <dl>
     <dt><a href="api/">COM API reference</a></dt>

--- a/developer/engine/desktop/web.config
+++ b/developer/engine/desktop/web.config
@@ -3,6 +3,12 @@
     <system.webServer>
         <rewrite>
             <rules>
+                <!-- Desktop engine content hasn't changed between 10.0 -> 12.0 -->
+                <rule name="Redirect 11.0/ and 12.0/ to 10.0/">
+                    <match url="(11|12)\.0(.*)" />
+                    <action type="Redirect" url="10.0{R:2}" />
+                </rule>
+
                 <rule name="Redirect unversioned paths to 10.0/ path">
                     <match url="^(.*)" />
                     <conditions>

--- a/developer/engine/iphone-and-ipad/web.config
+++ b/developer/engine/iphone-and-ipad/web.config
@@ -8,7 +8,7 @@
                     <conditions>
                         <add input="{URL}" pattern="(2|10|11|12)\.0(\/)?" negate="true" />
                     </conditions>
-                    <action type="Redirect" url="11.0/{R:1}" />
+                    <action type="Redirect" url="12.0/{R:1}" />
                 </rule>
             </rules>
         </rewrite>

--- a/developer/engine/web/web.config
+++ b/developer/engine/web/web.config
@@ -8,12 +8,12 @@
                     <action type="Redirect" url="2.0/{R:2}" />
                 </rule>
 
-                <rule name="Redirect unversioned paths to 11.0/ path">
+                <rule name="Redirect unversioned paths to 12.0/ path">
                     <match url="^(.*)" />
                     <conditions>
-                        <add input="{URL}" pattern="(1|2|10|11)\.0(\/)?" negate="true" />
+                        <add input="{URL}" pattern="(1|2|10|11|12)\.0(\/)?" negate="true" />
                     </conditions>
-                    <action type="Redirect" url="11.0/{R:1}" />
+                    <action type="Redirect" url="12.0/{R:1}" />
                 </rule>
 
                 <rule name="Ignore .php extension">

--- a/developer/index.php
+++ b/developer/index.php
@@ -23,7 +23,7 @@ $pagestyle = '#section2 .wrapper { overflow-x: inherit }';
     </a>
 </div>
 <div class="product" id="product-developer">
-    <a href="11.0/">
+    <a href="12.0/">
         <img src="<?php echo cdn("img/icon-developer.png"); ?>" />
         <h3>Keyman Developer</h3>
         <p>

--- a/developer/keyboards/_shared/designing-keyboard.php
+++ b/developer/keyboards/_shared/designing-keyboard.php
@@ -2,7 +2,7 @@
 
 <p>
     Use the documentation links above to learn how to create keyboard layouts;
-    <a href="https://help.keyman.com/developer/11.0/guides/" target="_blank">read the tutorials</a>,
+    <a href="https://help.keyman.com/developer/12.0/guides/" target="_blank">read the tutorials</a>,
     <a href="https://blog.keyman.com/category/developing-keyboards/" target="_blank">our blog</a>; the
     <a href="https://www.tavultesoft.com/keymandev/quality/" target="_blank">Keyboard Quality Whitepaper</a>
     (desktop focused keyboards) will be helpful for learning how to develop your keyboards and documentation

--- a/developer/keyboards/_shared/organize-include-exclude.php
+++ b/developer/keyboards/_shared/organize-include-exclude.php
@@ -21,7 +21,7 @@
 
     <dt><code>&lt;keyboard&gt;.kps</code></dt>
     <dd>The package source file. See the Keyman Developer
-        <a href="https://help.keyman.com/developer/11.0/guides/distribute/packages" target="_blank">reference</a>
+        <a href="https://help.keyman.com/developer/12.0/guides/distribute/packages" target="_blank">reference</a>
         for what to include within the package source file,
         but remember that when you reference any built files within the package, make sure you reference them from your
         <code><strong>build</strong></code> folder.</dd>

--- a/products/android/web.config
+++ b/products/android/web.config
@@ -3,12 +3,12 @@
     <system.webServer>
         <rewrite>
             <rules>
-                <rule name="Redirect unversioned paths to 11.0/ path">
+                <rule name="Redirect unversioned paths to 12.0/ path">
                     <match url="(.*)" />
                     <conditions>
                         <add input="{URL}" pattern="(version-history|\d+\.\d+)(\/)?" negate="true" />
                     </conditions>
-                    <action type="Redirect" url="11.0/{R:1}" />
+                    <action type="Redirect" url="12.0/{R:1}" />
                 </rule>
             </rules>
         </rewrite>

--- a/products/desktop/web.config
+++ b/products/desktop/web.config
@@ -3,12 +3,12 @@
     <system.webServer>
         <rewrite>
             <rules>
-                <rule name="Redirect unversioned paths to 11.0/ path">
+                <rule name="Redirect unversioned paths to 12.0/ path">
                     <match url="(.*)" />
                     <conditions>
                         <add input="{URL}" pattern="(version-history|\d+\.\d+)(\/)?" negate="true" />
                     </conditions>
-                    <action type="Redirect" url="11.0/{R:1}" />
+                    <action type="Redirect" url="12.0/{R:1}" />
                 </rule>
             </rules>
         </rewrite>

--- a/products/iphone-and-ipad/web.config
+++ b/products/iphone-and-ipad/web.config
@@ -8,7 +8,7 @@
                     <conditions>
                         <add input="{URL}" pattern="(version-history|\d+\.\d+)(\/)?" negate="true" />
                     </conditions>
-                    <action type="Redirect" url="11.0/{R:1}" />
+                    <action type="Redirect" url="12.0/{R:1}" />
                 </rule>
                 <rule name="Redirect current alpha (or beta, pre-help seeding) version links to the most current (beta/stable) path">
                     <match url="13\.0/(.*)" />

--- a/products/linux/web.config
+++ b/products/linux/web.config
@@ -3,12 +3,12 @@
     <system.webServer>
         <rewrite>
             <rules>
-                <rule name="Redirect unversioned paths to 11.0/ path">
+                <rule name="Redirect unversioned paths to 12.0/ path">
                     <match url="(.*)" />
                     <conditions>
                         <add input="{URL}" pattern="(version-history|\d+\.\d+)(\/)?" negate="true" />
                     </conditions>
-                    <action type="Redirect" url="11.0/{R:1}" />
+                    <action type="Redirect" url="12.0/{R:1}" />
                 </rule>
 
                 <rule name="Ignore .php extension">

--- a/products/mac/web.config
+++ b/products/mac/web.config
@@ -8,17 +8,17 @@
                     <action type="Redirect" url="{R:1}images/{R:3}" />
                 </rule>
                 
-                <rule name="images -> 11.0/images" stopProcessing="true">
+                <rule name="images -> 12.0/images" stopProcessing="true">
                     <match url="^(images)\b(.*)$" ignoreCase="true"/> 
-                    <action type="Redirect" url="/products/mac/11.0/{R:1}{R:2}" />
+                    <action type="Redirect" url="/products/mac/12.0/{R:1}{R:2}" />
                 </rule>
                 
-                <rule name="Redirect -> version 11.0">
+                <rule name="Redirect -> version 12.0">
                     <match url="^([^/.]+)?$" />
                     <conditions logicalGrouping="MatchAll" trackAllCaptures="false">
                       <add input="{URL}" pattern="(version-history|\d+\.\d+)(\/)?" negate="true" />
                     </conditions>
-                    <action type="Redirect" url="/products/mac/11.0/docs/{R:1}" />
+                    <action type="Redirect" url="/products/mac/12.0/docs/{R:1}" />
                 </rule>
             </rules>
         </rewrite>


### PR DESCRIPTION
Fixes #61

Per discussion with @mcdurdin , `/developer/engine/desktop/` links go to `10.0` with a small notice about the content applying to 11.0 and 12.0