### PR TITLE
[help.keyman.com] update kb0069

### DIFF
--- a/knowledge-base/kb0069.md
+++ b/knowledge-base/kb0069.md
@@ -1,39 +1,30 @@
-# Using Adobe Reader X with Keyman Desktop
+# Using Adobe Acrobat Reader with Keyman Desktop
 
 ### **NOTE**: This archived documentation has not been updated recently and may contain information that is no longer relevant
 
 
 <h1>Symptoms</h1>
-<p>When Adobe Reader X is open, you experience the following behaviour:</p>
-<ul>
-<li>Keyman Desktop crashes when closing Keyman.</li>
-<li>Keyman Desktop crashes when closing the On Screen Keyboard.</li>
-<li>Adobe Reader X won't let you type using a Keyman keyboard.</li>
-</ul>
+<p>When Adobe Acrobat Reader is open, you experience that you cannot type using a Keyman keyboard in the search box, the comment section nor the Fill & Sign .</p>
 
 <h1>Issue</h1>
-<p>The sandbox security feature of Adobe Reader X causes a known conflict with Keyman Desktop. You can find out more about the problem here:</p>
-<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href='http://blog.tavultesoft.com/2011/02/adobe-reader-xs-sandbox-and-keyman-desktop.html'>http://blog.tavultesoft.com/2011/02/adobe-reader-xs-sandbox-and-keyman-desktop.html</a></p>
+<p>The problem is that Adobe Acrobat Reader by default blocks all external applications from interaction, due to many longstanding security issues with it.</p>
 
 <h1>Resolution</h1>
 
-<p>Version 7.1.270.0 of Keyman Desktop 7 resolves the crash in Adobe Reader X. Upgrade to the latest version of Keyman Desktop 7 from the Support tab of Keyman Configuration or by downloading and installing Keyman Desktop 7 again.</p>
-
-<p>Keyman Desktop 7.1.270.0 does not resolve the issue with Keyman keyboards not typing in Adobe Reader X. For a simple workaround, you can turn off Protected Mode in Adobe Reader X. Here's how:</p>
+<p>Keyman Desktop 12 does not resolve the issue with Keyman keyboards not typing in Adobe Acrobat Reader. For a simple workaround, you can turn off Protected Mode in Adobe Acrobat Reader. Here's how:</p>
 
 <ol>
-<li>Open Adobe Reader X.</li>
-<li>Select Edit > Preferences.</li>
-<li>Select General in the Categories menu.</li> 
-<li>Untick 'Enable Protected Mode at startup'.</li>
+<li>In Adobe Acrobat Reader, open <b>Edit / Preferences</b></li>
+<li>Under <b>Security (Enhanced)</b>, deselect <b>Enable Protected Mode at startup</b></li>
 <li>Click OK.</li>
-<li>Restart Adobe Reader X.</li>
+<li>Restart Adobe Acrobat Reader</li>
 </ol>
 
-<p>If for any reason you would like to revert to Adobe Reader 9, it is available here:</p>
-<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href='http://get.adobe.com/reader/otherversions/'>http://get.adobe.com/reader/otherversions/</a></p> 
+<p>This workaround enables you to type using Keyman keyboard in Adobe Acrobat Reader in the search box and the comment section, but not in the Fill & Sign.</p>
 
 ## Applies to:
- * Keyman Desktop Corporate 7.0
- * Keyman Desktop Light 7.0
- * Keyman Desktop Professional 7.0
+ * Keyman Desktop 12
+ * Keyman Desktop 11
+ * Keyman Desktop 10
+ * Keyman Desktop 9
+ * Keyman Desktop 8

--- a/knowledge-base/kb0069.md
+++ b/knowledge-base/kb0069.md
@@ -1,8 +1,5 @@
 # Using Adobe Acrobat Reader with Keyman Desktop
 
-### **NOTE**: This archived documentation has not been updated recently and may contain information that is no longer relevant
-
-
 <h1>Symptoms</h1>
 <p>When Adobe Acrobat Reader is open, you experience that you cannot type using a Keyman keyboard in the search box, the comment section nor the Fill & Sign .</p>
 


### PR DESCRIPTION
Update a workaround for Keyman keyboard to type in Adobe Acrobat Reader.

Tests have been done for Keyman 8/9/10/11/12 to see if a Keyman keyboard can be typed in Adobe Acrobat Reader when the **Security (Enhanced)** is **ON**.
<table>
<tbody>
 <tr><td>&nbsp;</td><td>8</td><td>9</td><td>10</td><td>11</td><td>12</td></tr>
 <tr><td>Comment</td><td>v</td><td>v</td><td>v</td><td>v</td><td>v</td></tr>
 <tr><td>Find</td><td>v</td><td>v</td><td>v</td><td>v</td><td>v</td></tr>
 <tr><td>Fill & Sign</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td></tr>
</tbody></table>

v: typable, x: not typable