### PR TITLE
fix: document layer switch precedence

### DIFF
--- a/developer/12.0/guides/develop/creating-a-touch-keyboard-layout-for-amharic-the-nitty-gritty.php
+++ b/developer/12.0/guides/develop/creating-a-touch-keyboard-layout-for-amharic-the-nitty-gritty.php
@@ -392,6 +392,10 @@
 
   <p>to ensure that the key's scan code is ignored by the keyboard mapping.</p>
 
+  <p>When a key in a touch layout definition includes a <strong>Next Layer</strong> control, this takes precedence over 
+  setting layer via the <a href='/developer/language/reference/layer'><code>layer</code></a> store (as the <strong>Next Layer</strong> 
+  control is applied once the rule has finished processing).</p>
+
   <h4><a name="id488949" id="id488949"></a>subkey</h4>
 
   <p>Arrays of 'subkeys' or pop-up keys can be defined for any key, and will appear momentarily after the key is touched if not

--- a/developer/language/reference/layer.php
+++ b/developer/language/reference/layer.php
@@ -32,6 +32,10 @@ layer on the touch keyboard.</p>
 Some layer controls can also be made directly in the touch layout itself with the <strong>Next Layer</strong> control, but
 the <code>&amp;layer</code> store provides for finer control.</p>
 
+<p>When a key in a touch layout definition includes a <strong>Next Layer</strong> control, this takes precedence over 
+setting layer via the <code>layer</code> store (as the <strong>Next Layer</strong> control is applied once the rule
+has finished processing).</p>
+
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Example:_Using_layer" name="Example:_Using_layer">Example: Using <code>&amp;layer</code></h3>
@@ -42,7 +46,7 @@ the <code>&amp;layer</code> store provides for finer control.</p>
 
 <h2>Platforms</h2>
 
-<p>The <code>&amp;layer</code> store will be used in touch platforms. It is ignored on all other platforms.</p>
+<p>The <code>&amp;layer</code> store is used in touch platforms. It is ignored on all other platforms.</p>
 
 <table class='platform'>
   <thead>
@@ -56,7 +60,6 @@ the <code>&amp;layer</code> store provides for finer control.</p>
 <h2>Version history</h2>
 
 <p>The <code>&amp;layer</code> store was added in Keyman 9.0.</p>
-
 
 <h2 id="See_also" name="See_also">See also</h2>
 


### PR DESCRIPTION
Fixes #86.

It was unclear which control took precedence when both `nextlayer` and
`layer` were in use in a keyboard. tl;dr: `nextlayer`.