### PR TITLE
Add file types and fix constants documentation

### DIFF
--- a/developer/12.0/reference/file-types/index.php
+++ b/developer/12.0/reference/file-types/index.php
@@ -10,38 +10,38 @@
 
 <dl>
   <dt><a href="ico">ICO files</a></dt>
-  <dd>Keyboard icon files</dd>
+  <dd>Keyboard icon files (binary file format)</dd>
 
   <dt><a href="kmn">KMN files</a></dt>
-  <dd>Keyboard source files</dd>
+  <dd>Keyboard source files (text file format)</dd>
   
   <dt><a href="kmp">KMP files</a></dt>
-  <dd>Keyboard package files</dd>
+  <dd>Keyboard package files (zip file format)</dd>
   
   <dt><a href="kmx">KMX files</a></dt>
-  <dd>Keyboard files</dd>
+  <dd>Keyboard files (binary file format)</dd>
   
   <dt><a href="kpj">KPJ files</a></dt>
-  <dd>Keyman Developer Project files</dd>
+  <dd>Keyman Developer Project files (XML file format)</dd>
   
   <dt><a href="kps">KPS files</a></dt>
-  <dd>Keyboard package source files</dd>
+  <dd>Keyboard package source files (XML file format)</dd>
   
   <dt><a href="kvk">KVK files</a></dt>
-  <dd>Visual keyboard files</dd>
+  <dd>Visual keyboard files (binary file format)</dd>
 
   <dt><a href="kvks">KVKS files</a></dt>
-  <dd>Visual keyboard source files</dd>
+  <dd>Visual keyboard source files (XML file format)</dd>
 
   <dt><a href="model-js">MODEL.JS files</a></dt>
-  <dd>Lexical model files</dd>
+  <dd>Lexical model files (text file format)</dd>
 
   <dt><a href="model-ts">MODEL.TS files</a></dt>
-  <dd>Lexical model definition files</dd>
+  <dd>Lexical model definition files (text file format)</dd>
 
   <dt><a href="tsv">TSV files</a></dt>
-  <dd>Word list source files, exported in a compatible tab-separated values format.</dd>
+  <dd>Word list source files (tab-separated values file format)</dd>
 
   <dt><a href="keyman-touch-layout">keyman-touch-layout files</a></dt>
-  <dd>Keyman touch layout source files</dd>
+  <dd>Keyman touch layout source files (JSON file format)</dd>
 </dl>

--- a/developer/language/guide/constants.php
+++ b/developer/language/guide/constants.php
@@ -13,7 +13,7 @@
 or <code>$<var>charname</var></code>.</p>
 
 <p>The dollar referencing can only be used with named constants. You cannot use it for stores that have more than one character in
-them, or for keys or other non-character stores. Named constants are supported for characters above plane 0.</p>
+  them, or for keys or other non-character stores. Named constants are <strong>not</strong> supported for characters above plane 0.</p>
 
 <p>Named constants can also be loaded from a file with the <a class="link" href="../reference/includecodes" title=
 "&amp;includecodes system store"><code>&amp;includecodes</code> system store</a>. For instance, the Unicode Character Names can be used by


### PR DESCRIPTION
Fixes #87 adding file format details to https://help.keyman.com/DEVELOPER/12.0/reference/file-types/ 
Most of the individual file-type pages already listed file format details.

Also fixes documentation that named constants are **not** supported for characters above plane 0.