### PR TITLE
chore: rollback incorrect update to constants

### DIFF
--- a/developer/language/guide/constants.php
+++ b/developer/language/guide/constants.php
@@ -13,7 +13,7 @@
 or <code>$<var>charname</var></code>.</p>
 
 <p>The dollar referencing can only be used with named constants. You cannot use it for stores that have more than one character in
-  them, or for keys or other non-character stores. Named constants are <strong>not</strong> supported for characters above plane 0.</p>
+  them, or for keys or other non-character stores. Named constants are supported for all Unicode characters including BMP and SMP (above plane 0).</p>
 
 <p>Named constants can also be loaded from a file with the <a class="link" href="../reference/includecodes" title=
 "&amp;includecodes system store"><code>&amp;includecodes</code> system store</a>. For instance, the Unicode Character Names can be used by


### PR DESCRIPTION
This was a misdiagnosis of an unrelated issue
as shown in keymanapp/keyman#2398.

Rolling back change applied in #89.