### PR TITLE
Add linux to rest of Developer language reference tables

### DIFF
--- a/developer/language/reference/bitmap.php
+++ b/developer/language/reference/bitmap.php
@@ -50,10 +50,10 @@ to reference it.</p>
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✔</td><td>✔</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td></tr>
+    <tr><td>✔</td><td>✔</td><td>✔</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/call.php
+++ b/developer/language/reference/call.php
@@ -61,10 +61,10 @@ available in the <a href='/developer/current-version/guides/develop/imx/web'>IMX
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✔</td><td>✘</td><td>✔</td><td>✔</td><td>✔</td><td>✔</td></tr>
+    <tr><td>✔</td><td>✘</td><td>✘</td><td>✔</td><td>✔</td><td>✔</td><td>✔</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/caps.php
+++ b/developer/language/reference/caps.php
@@ -49,10 +49,10 @@ store(&amp;shiftfreescaps) "1"
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✔</td><td>✔</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td></tr>
+    <tr><td>✔</td><td>✔</td><td>✔</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/hotkey.php
+++ b/developer/language/reference/hotkey.php
@@ -53,10 +53,10 @@ As of Keyman Developer 13.0, the quotes are no longer required.</p>
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✔</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td></tr>
+    <tr><td>✔</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/includecodes.php
+++ b/developer/language/reference/includecodes.php
@@ -47,7 +47,7 @@ Developer.</p>
   <dt><code>CONSTANT_NAME</code></dt>
   <dd>A case insensitive name. Characters allowed are <code>A-Z</code>, <code>0-9</code>, space and
     underscore (<code>_</code>). Note that space will be converted to underscore (<code>_</code>) by 
-    Keyman Developer when the file is imported.</p>
+    Keyman Developer when the file is imported.</dd>
 
   <dt><code>additional data</code></dt>
   <dd>Ignored by Keyman Developer.</dd>
@@ -77,10 +77,10 @@ Developer.</p>
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✔</td><td>✔</td><td>✔</td><td>✔</td><td>✔</td><td>✔</td></tr>
+    <tr><td>✔</td><td>✔</td><td>✔</td><td>✔</td><td>✔</td><td>✔</td><td>✔</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/kmw_embedcss.php
+++ b/developer/language/reference/kmw_embedcss.php
@@ -50,10 +50,10 @@ the rest of the keyboard.</p>
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+  <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✘</td><td>✘</td><td>✔</td><td>✔</td><td>✔</td><td>✔</td></tr>
+    <tr><td>✘</td><td>✘</td><td>✘</td><td>✔</td><td>✔</td><td>✔</td><td>✔</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/kmw_embedjs.php
+++ b/developer/language/reference/kmw_embedjs.php
@@ -44,10 +44,10 @@ This is typically used with the <a href='call.php'><code>call()</code> statement
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✘</td><td>✘</td><td>✔</td><td>✔</td><td>✔</td><td>✔</td></tr>
+    <tr><td>✘</td><td>✘</td><td>✘</td><td>✔</td><td>✔</td><td>✔</td><td>✔</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/kmw_helpfile.php
+++ b/developer/language/reference/kmw_helpfile.php
@@ -45,10 +45,10 @@ will be a snippet only. On a desktop browser, the contents of this file will rep
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✘</td><td>✘</td><td>✔</td><td>✘</td><td>✘</td><td>✘</td></tr>
+    <tr><td>✘</td><td>✘</td><td>✘</td><td>✔</td><td>✘</td><td>✘</td><td>✘</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/kmw_helptext.php
+++ b/developer/language/reference/kmw_helptext.php
@@ -42,10 +42,10 @@ desktop web browsers. It is mutually exclusive with the <a href='kmw_helpfile.ph
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✘</td><td>✘</td><td>✔</td><td>✘</td><td>✘</td><td>✘</td></tr>
+    <tr><td>✘</td><td>✘</td><td>✘</td><td>✔</td><td>✘</td><td>✘</td><td>✘</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/kmw_rtl.php
+++ b/developer/language/reference/kmw_rtl.php
@@ -43,10 +43,10 @@ for Web will use this flag to set the directionality of edit controls.</p>
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✘</td><td>✘</td><td>✔</td><td>✔</td><td>✘</td><td>✘</td></tr>
+    <tr><td>✘</td><td>✘</td><td>✘</td><td>✔</td><td>✔</td><td>✘</td><td>✘</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/language.php
+++ b/developer/language/reference/language.php
@@ -66,10 +66,10 @@ reference</a></p>
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✔</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td></tr>
+    <tr><td>✔</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/layer.php
+++ b/developer/language/reference/layer.php
@@ -50,10 +50,10 @@ has finished processing).</p>
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✘</td><td>✘</td><td>✘</td><td>✔</td><td>✔</td><td>✔</td></tr>
+    <tr><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✔</td><td>✔</td><td>✔</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/layout.php
+++ b/developer/language/reference/layout.php
@@ -23,10 +23,10 @@
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td></tr>
+    <tr><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/layoutfile.php
+++ b/developer/language/reference/layoutfile.php
@@ -56,10 +56,10 @@ on the US English desktop keyboard layout.</p>
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✘</td><td>✘</td><td>✘</td><td>✔</td><td>✔</td><td>✔</td></tr>
+    <tr><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✔</td><td>✔</td><td>✔</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/return.php
+++ b/developer/language/reference/return.php
@@ -38,10 +38,10 @@ will skip <a href='match.php'><code>match</code> rules</a>, for example.</p>
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✔</td><td>✔</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td></tr>
+    <tr><td>✔</td><td>✔</td><td>✔</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td></tr>
   </tbody>
 </table>
 

--- a/developer/language/reference/windowslanguages.php
+++ b/developer/language/reference/windowslanguages.php
@@ -47,10 +47,10 @@ reference</a></p>
 
 <table class='platform'>
   <thead>
-    <tr><th>Windows</th><th>macOS</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
+    <tr><th>Windows</th><th>macOS</th><th>Linux</th><th>Desktop web</th><th>Mobile web</th><th>iOS</th><th>Android</th></tr>
   </thead>
   <tbody>
-    <tr><td>✔</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td></tr>
+    <tr><td>✔</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td><td>✘</td></tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Addresses this comment on #11 
> Platforms sections in language reference need update for Linux.

and picking up after #98 