### PR TITLE
fix: support keyboard fonts

### DIFF
--- a/_includes/includes/head.php
+++ b/_includes/includes/head.php
@@ -60,20 +60,15 @@
    window.attachEvent("onload", downloadJSAtOnload);
    else window.onload = downloadJSAtOnload;
   </script>
-  <?php if(isset($IncludeKeymanWeb) && $IncludeKeymanWeb == true){ ?>
-    <script src='https://s.keyman.com/kmw/engine/10.0.103/keymanweb.js'></script>
-
-<!--
-<script src="http://s.keyman.com/kmw/engine/377/src/kmwstring.js" type="application/javascript"></script>
-<script src="http://s.keyman.com/kmw/engine/377/src/kmwbase.js" type="application/javascript"></script>
-<script src="http://s.keyman.com/kmw/engine/377/src/keymanweb.js" type="application/javascript"></script>
-<script src="http://s.keyman.com/kmw/engine/377/src/kmwosk.js" type="application/javascript"></script>
-<script src="http://s.keyman.com/kmw/engine/377/src/kmwnative.js" type="application/javascript"></script>
-<script src="http://s.keyman.com/kmw/engine/377/src/kmwcallback.js" type="application/javascript"></script>
-<script src="http://s.keyman.com/kmw/engine/377/src/kmwkeymaps.js" type="application/javascript"></script>
-<script src="http://s.keyman.com/kmw/engine/377/src/kmwlayout.js" type="application/javascript"></script>
-<script src="http://s.keyman.com/kmw/engine/377/src/kmwinit.js" type="application/javascript"></script>
--->
+  <?php if(isset($IncludeKeymanWeb) && $IncludeKeymanWeb == true){
+    $kmw_version_number = '10.0.103';
+    $kmw_version = @file_get_contents('https://api.keyman.com/version/web/stable');
+    if($kmw_version !== FALSE) {
+      $kmw_version = @json_decode($kmw_version);
+      if($kmw_version !== NULL) $kmw_version_number = $kmw_version->version;
+    }
+  ?>
+    <script src='https://s.keyman.com/kmw/engine/<?=$kmw_version_number?>/keymanweb.js'></script>
     <script>
       keyman.init({keyboards:'https://s.keyman.com/keyboard/'});
     </script>

--- a/cdn/dev/js/kbd-docs.js
+++ b/cdn/dev/js/kbd-docs.js
@@ -10,11 +10,11 @@ function loaded(){
   $('#testimonial').click(function(){
     location.href="http://www.tavultesoft.com/testimonials.php";
   });
-  
+
   // Email subscribe form
   $('.subscribe').click(function(){
     $('#mc-embedded-subscribe-form').submit();
-  });    
+  });
 
   // Popup close
   $('#popup-close').click(function(){
@@ -32,9 +32,9 @@ function loaded(){
 	$('.popup').fadeOut(300);
     }
   });
-  
+
   // Scrolling top menu functionality (Non touch devices only)
-  var 
+  var
     device = $(document.body).data('device'),
     scrollFix = function(e) {
       var scroller_anchor = $(".header").height();
@@ -48,7 +48,7 @@ function loaded(){
         $('#toc').removeClass('fixed');
       }
     };
-    
+
   if (device != 'Android' && device != 'iPhone' && device != 'iPad') {
     $(window).scroll(scrollFix);
   }
@@ -61,10 +61,10 @@ function loaded(){
       }else{
         $("body").css("overflow","auto");
         $("#phone-menu").hide();
-      }	
+      }
     });
   }
-  
+
   // Footer to bottom of page
   var link = $('.footer');
   var offset = link.offset().top;
@@ -72,19 +72,50 @@ function loaded(){
   if (diff > 0) {
     link.css('margin-top',diff);
   }
-  
+
   (function(){
     // Insert keyboard into osk div
-    
+
     var url = location.pathname.split('/');
     var keyboardName = url[url.length-3], keyboardVersion = url[url.length-2];
     var keyboardPath = keyman.options['keyboards'] + keyboardName + '/' + keyboardVersion + '/' + keyboardName + '-' + keyboardVersion + '.js';
+
+    var fontFamily = null, fontSource = null;
+
+    // This retrieves font info from latest version of keyboard; we don't currently have that available for earlier versions. No worries.
+    $.ajax({
+      url: 'https://api.keyman.com/keyboard/' + keyboardName,
+      success:function(data) {
+        if(typeof data != 'object') return;
+        for(var lang in data.languages) {
+          if(data.languages[lang].font) {
+            // pick the first font
+            fontFamily = data.languages[lang].font.family;
+            fontSource = data.languages[lang].font.source;
+            /* Add the font information */
+            $('head').append($(`
+<style>
+@font-face {
+	font-family:"${fontFamily}";
+	font-style:normal;
+	font-weight:normal;
+	src:url('https://s.keyman.com/font/deploy/${fontSource}') format('truetype');
+}
+.kmw-key-text { font-family: "${fontFamily}"; }
+</style>
+`));
+            return;
+          }
+        }
+      }
+    });
+
     $.ajax({
       url:keyboardPath,
       success:function() {
-      
+
         var addKeyboards = function(element, platform) {
-          var 
+          var
             osk = $(element),
             states = osk.data('states'),
             addKeyboard = function(name, platform, title) {
@@ -98,9 +129,9 @@ function loaded(){
                 return platform == 'desktop' ? 320 :
                        platform == 'phone' ? 240 : 360;
               };
-              
-              var note = null; 
-              
+
+              var note = null;
+
               var kbd = keyman.BuildVisualKeyboard(keyboardName, 1, platform, name);
               if (kbd) {
                 osk.append('<h3>'+title+'</h3>', kbd);
@@ -112,7 +143,7 @@ function loaded(){
             toTitleCase = function(str) {
               return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
             };
-            
+
           if(osk.length == 0) return; // no place for it
           if(!states) states='default shift';
           states=states.split(' ');
@@ -155,7 +186,7 @@ function loaded(){
       cache:true
     });
   })();
-  
+
   /*!
    * toc - jQuery Table of Contents Plugin
    * v0.3.2
@@ -223,7 +254,7 @@ function loaded(){
     var headings = $(opts.selectors, container);
     var headingOffsets = [];
     var activeClassName = opts.activeClass;
-    
+
     if(opts.filter) headings = headings.filter(opts.filter);
 
     var scrollTo = function(e, callback) {
@@ -246,7 +277,7 @@ function loaded(){
       timeout = setTimeout(function() {
         var top = $(window).scrollTop(),
           highlighted, closest = Number.MAX_VALUE, index = 0;
-        
+
         for (var i = 0, c = headingOffsets.length; i < c; i++) {
           var currentClosest = Math.abs(headingOffsets[i] - top);
           if (currentClosest < closest) {
@@ -254,10 +285,10 @@ function loaded(){
             closest = currentClosest;
           }
         }
-        
+
         $('li', self).removeClass(activeClassName);
         highlighted = $('li:eq('+ index +')', self).addClass(activeClassName);
-        opts.onHighlight(highlighted);      
+        opts.onHighlight(highlighted);
       }, 50);
     };
     if (opts.highlightOnScroll) {
@@ -330,12 +361,12 @@ function loaded(){
       var candidateId = $(heading).text().replace(/[^a-z0-9]/ig, ' ').replace(/\s+/g, '-').toLowerCase();
       if (verboseIdCache[candidateId]) {
         var j = 2;
-        
+
         while(verboseIdCache[candidateId + j]) {
           j++;
         }
         candidateId = candidateId + '-' + j;
-        
+
       }
       verboseIdCache[candidateId] = true;
 
@@ -351,7 +382,7 @@ function loaded(){
   };
 
   })(jQuery);
-  
+
 /**
   Build Table of Contents after page content is loaded
 */
@@ -362,11 +393,11 @@ function loaded(){
       'scrollToOffset' : 120,
       'filter' : function(index, element) { return $(element).parents('.tip,.note').length == 0; }
     });
-    
+
     if($('#toc-content li').length >= 2 && ['developer','keyboard'].indexOf($('body').data('section')) >= 0) {
       $('.column-right').addClass('show-toc');
-    } 
-    
+    }
+
     $(window).resize(function() {
       $('#toc').css('max-height', window.innerHeight-180 + 'px');
     });
@@ -379,4 +410,3 @@ function loaded(){
 
 loaded();
 
-  

--- a/cdn/dev/js/kbd-docs.js
+++ b/cdn/dev/js/kbd-docs.js
@@ -121,29 +121,26 @@ function loaded(){
             states = osk.data('states'),
             addKeyboard = function(name, platform, title) {
 
-              keyman.setActiveKeyboard(keyboardName).then(function() {
+              // TODO: These hacks are pretty awful
+              keyman.getOskWidth = function() {
+                return platform == 'desktop' ? 960 :
+                        platform == 'phone' ? 520 : 720;
+              };
 
-                keyman.getOskWidth = function() {
-                  return platform == 'desktop' ? 960 :
-                         platform == 'phone' ? 520 : 720;
-                };
+              keyman.getOskHeight = function() {
+                return platform == 'desktop' ? 320 :
+                        platform == 'phone' ? 240 : 360;
+              };
 
-                  keyman.getOskHeight = function() {
-                  return platform == 'desktop' ? 320 :
-                         platform == 'phone' ? 240 : 360;
-                };
+              var note = null;
 
-                var note = null;
+              var kbd = keyman.BuildVisualKeyboard(keyboardName, 1, platform, name);
+              if (kbd) {
+                osk.append('<h3>'+title+'</h3>', kbd);
+                if(note) osk.append(note);
+              }
 
-                var kbd = keyman.BuildVisualKeyboard(keyboardName, 1, platform, name);
-                if (kbd) {
-                  osk.append('<h3>'+title+'</h3>', kbd);
-                  if(note) osk.append(note);
-                }
-
-                keyman.getOskWidth = keyman.getOskHeight = null;
-
-              });
+              keyman.getOskWidth = keyman.getOskHeight = null;
             },
             toTitleCase = function(str) {
               return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});

--- a/cdn/dev/js/kbd-docs.js
+++ b/cdn/dev/js/kbd-docs.js
@@ -83,6 +83,7 @@ function loaded(){
     var fontFamily = null, fontSource = null;
 
     // This retrieves font info from latest version of keyboard; we don't currently have that available for earlier versions. No worries.
+    // TODO: this would be better integrated into using KeymanWeb to retrieve this information directly. However, it will do for now.
     $.ajax({
       url: 'https://api.keyman.com/keyboard/' + keyboardName,
       success:function(data) {
@@ -92,7 +93,7 @@ function loaded(){
             // pick the first font
             fontFamily = data.languages[lang].font.family;
             fontSource = data.languages[lang].font.source;
-            /* Add the font information */
+            // Add the font information
             $('head').append($(`
 <style>
 @font-face {
@@ -120,25 +121,29 @@ function loaded(){
             states = osk.data('states'),
             addKeyboard = function(name, platform, title) {
 
-              keyman.getOskWidth = function() {
-                return platform == 'desktop' ? 960 :
-                       platform == 'phone' ? 520 : 720;
-              };
+              keyman.setActiveKeyboard(keyboardName).then(function() {
 
-                keyman.getOskHeight = function() {
-                return platform == 'desktop' ? 320 :
-                       platform == 'phone' ? 240 : 360;
-              };
+                keyman.getOskWidth = function() {
+                  return platform == 'desktop' ? 960 :
+                         platform == 'phone' ? 520 : 720;
+                };
 
-              var note = null;
+                  keyman.getOskHeight = function() {
+                  return platform == 'desktop' ? 320 :
+                         platform == 'phone' ? 240 : 360;
+                };
 
-              var kbd = keyman.BuildVisualKeyboard(keyboardName, 1, platform, name);
-              if (kbd) {
-                osk.append('<h3>'+title+'</h3>', kbd);
-                if(note) osk.append(note);
-              }
+                var note = null;
 
-              keyman.getOskWidth = keyman.getOskHeight = null;
+                var kbd = keyman.BuildVisualKeyboard(keyboardName, 1, platform, name);
+                if (kbd) {
+                  osk.append('<h3>'+title+'</h3>', kbd);
+                  if(note) osk.append(note);
+                }
+
+                keyman.getOskWidth = keyman.getOskHeight = null;
+
+              });
             },
             toTitleCase = function(str) {
               return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});

--- a/cdn/dev/js/kbd-docs.js
+++ b/cdn/dev/js/kbd-docs.js
@@ -84,6 +84,20 @@ function loaded(){
 
     // This retrieves font info from latest version of keyboard; we don't currently have that available for earlier versions. No worries.
     // TODO: this would be better integrated into using KeymanWeb to retrieve this information directly. However, it will do for now.
+
+    function getFirstTTF(a) {
+      var ttfPattern = /\.(ttf|otf|woff)$/i;
+      if(typeof a == 'string') {
+        return a.match(ttfPattern) ? a : null;
+      }
+
+      // a is an array
+      for(var o in a) {
+        if(a[o].match(ttfPattern)) return a[o];
+      }
+      return null;
+    }
+
     $.ajax({
       url: 'https://api.keyman.com/keyboard/' + keyboardName,
       success:function(data) {
@@ -92,7 +106,9 @@ function loaded(){
           if(data.languages[lang].font) {
             // pick the first font
             fontFamily = data.languages[lang].font.family;
-            fontSource = data.languages[lang].font.source;
+            fontSource = getFirstTTF(data.languages[lang].font.source);
+            if(!fontSource) continue;
+            var fontType = fontSource.match(/\.woff$/i) ? 'woff' : 'truetype';
             // Add the font information
             $('head').append($(`
 <style>
@@ -100,7 +116,7 @@ function loaded(){
 	font-family:"${fontFamily}";
 	font-style:normal;
 	font-weight:normal;
-	src:url('https://s.keyman.com/font/deploy/${fontSource}') format('truetype');
+	src:url('https://s.keyman.com/font/deploy/${fontSource}') format('${fontType}');
 }
 .kmw-key-text { font-family: "${fontFamily}"; }
 </style>


### PR DESCRIPTION
This is a quick fix to get keyboard fonts working
on help pages; it relies on api.keyman.com,
s.keyman.com being in sync. In future we should
look at leveraging KeymanWeb's built-in font
support but that requires more re-engineering
of the help kbd-docs js.

Fixes #150.