### PR TITLE
feat: allows testing keyboard help pages with dev KMW

### DIFF
--- a/_includes/includes/head.php
+++ b/_includes/includes/head.php
@@ -4,6 +4,10 @@
   require_once('servervars.php');
   require_once('page-version.php');
 
+  // Variables used to manage and trigger debugging tests.
+  // Simply defining the variable below is enough to trigger debug mode.
+  // $kmw_dev_path = 'http://localhost/release/unminified/web';
+
   if(!isset($title)){
     $title = 'Keyman | Type to the world in your language';
   }
@@ -15,7 +19,7 @@
   }
   if(!empty($kbdname))
   {
-    require_once('renderlanguageExample.php');
+    require_once('renderLanguageExample.php');
     $kb_doc = true;
   }else{
     $kb_doc = false;
@@ -67,8 +71,16 @@
       $kmw_version = @json_decode($kmw_version);
       if($kmw_version !== NULL) $kmw_version_number = $kmw_version->version;
     }
+    if(!isset($kmw_dev_path)) {
   ?>
-    <script src='https://s.keyman.com/kmw/engine/<?=$kmw_version_number?>/keymanweb.js'></script>
+      <script src='https://s.keyman.com/kmw/engine/<?=$kmw_version_number?>/keymanweb.js'></script>
+  <?php
+    } else {
+  ?>
+      <script src='<?=$kmw_dev_path?>/keymanweb.js'></script>
+  <?php
+    }
+  ?>
     <script>
       keyman.init({keyboards:'https://s.keyman.com/keyboard/'});
     </script>


### PR DESCRIPTION
I was having a few issues trying to investigate https://github.com/keymanapp/keyman/issues/2818.  This simple setup allows easily debugging situations like this with the website in the future by allowing tests to run against local builds (as hosted by a local webserver).

With this in place, simply uncomment line 9 and edit it to match your local setup so that it accesses a valid build product for KMW.

Note:  is based on #149 because it further edits some of the same code.  And #149 was referenced in https://github.com/keymanapp/keyman/issues/2818, anyway.

Also of note:  there's a lot of duplicated code between this and __kmwheader.php (another include), but sorting that out is likely a matter for another day.  This tweak was directly inspired by its setup.