### PR TITLE
fix: use /developer/current-version for LMLayer doc links

### DIFF
--- a/developer/lexical-models/_shared/organize-folder-structure.php
+++ b/developer/lexical-models/_shared/organize-folder-structure.php
@@ -23,7 +23,7 @@
 
   <dt><code>source\&lt;wordlist&gt;.tsv</code></dt>
   <dd>wordlist source file, in columns for words, counts, and comments. This is a
-    <a href="../../12.0/reference/file-types/tsv.php">tab-separated value</a> file.</dd>
+    <a href="/developer/current-version/reference/file-types/tsv.php">tab-separated value</a> file.</dd>
 
   <dt><code>&lt;lexical-model&gt;.kpj</code></dt>
   <dd>the Keyman Developer project file for the lexical model<br/>

--- a/developer/lexical-models/_shared/organize-include-exclude.php
+++ b/developer/lexical-models/_shared/organize-include-exclude.php
@@ -15,7 +15,7 @@
 
     <dt><code>&lt;lexical model&gt;.kps</code></dt>
     <dd>The package source file. See the Keyman Developer
-        <a href="../../12.0/guides/lexical-models/distribute/tutorial" target="_blank">reference</a>
+        <a href="/developer/current-version/guides/lexical-models/distribute/tutorial" target="_blank">reference</a>
         for what to include within the package source file.
         Remember that when you reference any built files within the package, make sure you reference them from your
         <code><strong>build</strong></code> folder.</dd>

--- a/developer/lexical-models/index.php
+++ b/developer/lexical-models/index.php
@@ -83,7 +83,7 @@
 
 <ul class='menu'>
     <p>
-      For users who are <a href="../12.0/guides/lexical-models/">creating</a> and submitting a lexical model,
+      For users who are <a href="/developer/current-version/guides/lexical-models/">creating</a> and submitting a lexical model,
       learn how to get set up with the lexical models repository on GitHub and the Keyman tools.
     </p>
     <li><a href="submission">Lexical Model Submission Guide</a></li>


### PR DESCRIPTION
There were a few links pointing to 12.0 documentation for lexical models. I've updated them to use `current-version` so that they're always up-to-date.