### PR TITLE
docs(common/lmlayer): tweak docs for word breaker and search term to key

### DIFF
--- a/developer/13.0/context/model-editor.php
+++ b/developer/13.0/context/model-editor.php
@@ -53,12 +53,12 @@ which can be seen in the <strong>Source</strong> tab:</p>
   <dt>Format</dt>
   <dd>The implementation of the lexical model. This can be either <strong>Wordlist</strong> (<code>trie-1.0</code>), or
   <strong>Custom</strong> (<code>custom-1.0</code>).
-  Corresponds to the <code>format</code> property in the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts source file</a>.</dd>
+  Corresponds to the <code>format</code> property in the <a href="../reference/file-types/model-ts">.model.ts source file</a>.</dd>
 
   <dt>Word breaker</dt>
   <dd>What method is used to separate words in text. This can be one of <code>default</code>, <code>ascii</code>,
   or <code>custom</code>.
-  Corresponds to the <code>wordBreaker</code> property in the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts source file</a>.</dd>
+  Corresponds to the <code>wordBreaker</code> property in the <a href="../reference/file-types/model-ts">.model.ts source file</a>.</dd>
 
   <dt>Comments</dt>
   <dd>This field corresponds to the first lines of comments in the model source, and is visible only to the model designer.</dd>
@@ -67,10 +67,10 @@ which can be seen in the <strong>Source</strong> tab:</p>
   <dd>The Wordlists grid controls which additional wordlist files are referenced by the model. Adding a wordlist file will
   add an extra tab to the editor, and add the corresponding reference to the lexical model source. Removing a wordlist will not
   delete the component file, but will just remove the reference from the lexical model source.
-  Corresponds to the <code>sources</code> property in the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts source file</a>.</dd>
+  Corresponds to the <code>sources</code> property in the <a href="../reference/file-types/model-ts">.model.ts source file</a>.</dd>
 </dl>
 
-<p>Note: if the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts</a> file cannot be parsed by the model editor,
+<p>Note: if the <a href="../reference/file-types/model-ts">.model.ts</a> file cannot be parsed by the model editor,
 the field shown here will be read only and you will need to
 make changes only in the <strong>Source</strong> tab. This can happen if the .model.ts contains more complex code.</p>
 

--- a/developer/13.0/context/model-editor.php
+++ b/developer/13.0/context/model-editor.php
@@ -51,13 +51,14 @@ which can be seen in the <strong>Source</strong> tab:</p>
 
 <dl id="details-fields">
   <dt>Format</dt>
-  <dd>The format of the lexical model. This can be either <strong>Wordlist</strong> (<code>trie-1.0</code>), or
-  <strong>Custom</strong> (<code>custom-1.0</code>). Corresponds to the <code>format</code> variable in the .model.ts source
-  file.</dd>
+  <dd>The implementation of the lexical model. This can be either <strong>Wordlist</strong> (<code>trie-1.0</code>), or
+  <strong>Custom</strong> (<code>custom-1.0</code>).
+  Corresponds to the <code>format</code> property in the .model.ts source file.</dd>
 
   <dt>Word breaker</dt>
-  <dd>The word breaking algorithm used when generating suggestions. This can be one of <code>default</code>, <code>ascii</code>,
-  or <code>custom</code>. Corresponds to the <code>wordBreaker</code> variable in the .model.ts source file.</dd>
+  <dd>What method is used to separate words in text. This can be one of <code>default</code>, <code>ascii</code>,
+  or <code>custom</code>.
+  Corresponds to the <code>wordBreaker</code> property in the .model.ts source file.</dd>
 
   <dt>Comments</dt>
   <dd>This field corresponds to the first lines of comments in the model source, and is visible only to the model designer.</dd>

--- a/developer/13.0/context/model-editor.php
+++ b/developer/13.0/context/model-editor.php
@@ -53,12 +53,12 @@ which can be seen in the <strong>Source</strong> tab:</p>
   <dt>Format</dt>
   <dd>The implementation of the lexical model. This can be either <strong>Wordlist</strong> (<code>trie-1.0</code>), or
   <strong>Custom</strong> (<code>custom-1.0</code>).
-  Corresponds to the <code>format</code> property in the .model.ts source file.</dd>
+  Corresponds to the <code>format</code> property in the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts source file</a>.</dd>
 
   <dt>Word breaker</dt>
   <dd>What method is used to separate words in text. This can be one of <code>default</code>, <code>ascii</code>,
   or <code>custom</code>.
-  Corresponds to the <code>wordBreaker</code> property in the .model.ts source file.</dd>
+  Corresponds to the <code>wordBreaker</code> property in the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts source file</a>.</dd>
 
   <dt>Comments</dt>
   <dd>This field corresponds to the first lines of comments in the model source, and is visible only to the model designer.</dd>
@@ -66,11 +66,12 @@ which can be seen in the <strong>Source</strong> tab:</p>
   <dt>Wordlists</dt>
   <dd>The Wordlists grid controls which additional wordlist files are referenced by the model. Adding a wordlist file will
   add an extra tab to the editor, and add the corresponding reference to the lexical model source. Removing a wordlist will not
-  delete the component file, but will just remove the reference from the lexical model source. Corresponds to the
-  <code>sources</code> variable in the .model.ts source file.</dd>
+  delete the component file, but will just remove the reference from the lexical model source.
+  Corresponds to the <code>sources</code> property in the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts source file</a>.</dd>
 </dl>
 
-<p>Note: if the .model.ts file cannot be parsed by the model editor, the field shown here will be read only and you will need to
+<p>Note: if the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts</a> file cannot be parsed by the model editor,
+the field shown here will be read only and you will need to
 make changes only in the <strong>Source</strong> tab. This can happen if the .model.ts contains more complex code.</p>
 
 <h2 id="wordlist.tsv">Wordlist tabs</h2>

--- a/developer/14.0/context/model-editor.php
+++ b/developer/14.0/context/model-editor.php
@@ -53,12 +53,12 @@ which can be seen in the <strong>Source</strong> tab:</p>
   <dt>Format</dt>
   <dd>The implementation of the lexical model. This can be either <strong>Wordlist</strong> (<code>trie-1.0</code>), or
   <strong>Custom</strong> (<code>custom-1.0</code>).
-  Corresponds to the <code>format</code> property in the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts source file</a>.</dd>
+  Corresponds to the <code>format</code> property in the <a href="../reference/file-types/model-ts">.model.ts source file</a>.</dd>
 
   <dt>Word breaker</dt>
   <dd>What method is used to separate words in text. This can be one of <code>default</code>, <code>ascii</code>,
   or <code>custom</code>.
-  Corresponds to the <code>wordBreaker</code> property in the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts source file</a>.</dd>
+  Corresponds to the <code>wordBreaker</code> property in the <a href="../reference/file-types/model-ts">.model.ts source file</a>.</dd>
 
   <dt>Comments</dt>
   <dd>This field corresponds to the first lines of comments in the model source, and is visible only to the model designer.</dd>
@@ -67,10 +67,10 @@ which can be seen in the <strong>Source</strong> tab:</p>
   <dd>The Wordlists grid controls which additional wordlist files are referenced by the model. Adding a wordlist file will
   add an extra tab to the editor, and add the corresponding reference to the lexical model source. Removing a wordlist will not
   delete the component file, but will just remove the reference from the lexical model source.
-  Corresponds to the <code>sources</code> property in the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts source file</a>.</dd>
+  Corresponds to the <code>sources</code> property in the <a href="../reference/file-types/model-ts">.model.ts source file</a>.</dd>
 </dl>
 
-<p>Note: if the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts</a> file cannot be parsed by the model editor,
+<p>Note: if the <a href="../reference/file-types/model-ts">.model.ts</a> file cannot be parsed by the model editor,
 the field shown here will be read only and you will need to
 make changes only in the <strong>Source</strong> tab. This can happen if the .model.ts contains more complex code.</p>
 

--- a/developer/14.0/context/model-editor.php
+++ b/developer/14.0/context/model-editor.php
@@ -51,13 +51,14 @@ which can be seen in the <strong>Source</strong> tab:</p>
 
 <dl id="details-fields">
   <dt>Format</dt>
-  <dd>The format of the lexical model. This can be either <strong>Wordlist</strong> (<code>trie-1.0</code>), or
-  <strong>Custom</strong> (<code>custom-1.0</code>). Corresponds to the <code>format</code> variable in the .model.ts source
-  file.</dd>
+  <dd>The implementation of the lexical model. This can be either <strong>Wordlist</strong> (<code>trie-1.0</code>), or
+  <strong>Custom</strong> (<code>custom-1.0</code>).
+  Corresponds to the <code>format</code> property in the .model.ts source file.</dd>
 
   <dt>Word breaker</dt>
-  <dd>The word breaking algorithm used when generating suggestions. This can be one of <code>default</code>, <code>ascii</code>,
-  or <code>custom</code>. Corresponds to the <code>wordBreaker</code> variable in the .model.ts source file.</dd>
+  <dd>What method is used to separate words in text. This can be one of <code>default</code>, <code>ascii</code>,
+  or <code>custom</code>.
+  Corresponds to the <code>wordBreaker</code> property in the .model.ts source file.</dd>
 
   <dt>Comments</dt>
   <dd>This field corresponds to the first lines of comments in the model source, and is visible only to the model designer.</dd>

--- a/developer/14.0/context/model-editor.php
+++ b/developer/14.0/context/model-editor.php
@@ -53,12 +53,12 @@ which can be seen in the <strong>Source</strong> tab:</p>
   <dt>Format</dt>
   <dd>The implementation of the lexical model. This can be either <strong>Wordlist</strong> (<code>trie-1.0</code>), or
   <strong>Custom</strong> (<code>custom-1.0</code>).
-  Corresponds to the <code>format</code> property in the .model.ts source file.</dd>
+  Corresponds to the <code>format</code> property in the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts source file</a>.</dd>
 
   <dt>Word breaker</dt>
   <dd>What method is used to separate words in text. This can be one of <code>default</code>, <code>ascii</code>,
   or <code>custom</code>.
-  Corresponds to the <code>wordBreaker</code> property in the .model.ts source file.</dd>
+  Corresponds to the <code>wordBreaker</code> property in the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts source file</a>.</dd>
 
   <dt>Comments</dt>
   <dd>This field corresponds to the first lines of comments in the model source, and is visible only to the model designer.</dd>
@@ -66,11 +66,12 @@ which can be seen in the <strong>Source</strong> tab:</p>
   <dt>Wordlists</dt>
   <dd>The Wordlists grid controls which additional wordlist files are referenced by the model. Adding a wordlist file will
   add an extra tab to the editor, and add the corresponding reference to the lexical model source. Removing a wordlist will not
-  delete the component file, but will just remove the reference from the lexical model source. Corresponds to the
-  <code>sources</code> variable in the .model.ts source file.</dd>
+  delete the component file, but will just remove the reference from the lexical model source.
+  Corresponds to the <code>sources</code> property in the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts source file</a>.</dd>
 </dl>
 
-<p>Note: if the .model.ts file cannot be parsed by the model editor, the field shown here will be read only and you will need to
+<p>Note: if the <a href="/developer/current-version/reference/file-types/model-ts">.model.ts</a> file cannot be parsed by the model editor,
+the field shown here will be read only and you will need to
 make changes only in the <strong>Source</strong> tab. This can happen if the .model.ts contains more complex code.</p>
 
 <h2 id="wordlist.tsv">Wordlist tabs</h2>

--- a/developer/14.0/guides/lexical-models/advanced/model-definition-file.php
+++ b/developer/14.0/guides/lexical-models/advanced/model-definition-file.php
@@ -54,7 +54,7 @@ quickly. </p>
 <pre><code class="lang-typescript">  format: 'trie-1.0',</code></pre>
 
 <p> On lines 3–5, we're specifying the word breaking algorithm that we want to use.
-Keyman supplies a default algorithm that conforms to the rules expected for many Latin-script
+Keyman supplies a default algorithm that conforms to the rules expected for many 
 languages.</p>
 <pre><code class="lang-typescript">  wordBreaker: {
   use: 'default',

--- a/developer/14.0/guides/lexical-models/advanced/model-definition-file.php
+++ b/developer/14.0/guides/lexical-models/advanced/model-definition-file.php
@@ -34,6 +34,9 @@ in the same folder as <code>wordlist.tsv</code>.</p>
 
 const source: LexicalModelSource = {
   format: 'trie-1.0',
+  wordBreaker: {
+    use: 'default',
+  },
   sources: ['wordlist.tsv'],
 };
 export default source;</code></pre>
@@ -50,17 +53,24 @@ lexical model such that it can predict through thousands of words very
 quickly. </p>
 <pre><code class="lang-typescript">  format: 'trie-1.0',</code></pre>
 
-<p> On the third line, we're telling the <code>trie</code> where to find our wordlist. </p>
+<p> On lines 3–5, we're specifying the word breaking algorithm that we want to use.
+Keyman supplies a default algorithm that conforms to the rules expected for many Latin-script
+languages.</p>
+<pre><code class="lang-typescript">  wordBreaker: {
+  use: 'default',
+},</code></pre>
+
+<p> On the sixth line, we're telling the <code>trie</code> where to find our wordlist. </p>
 <pre><code class="lang-typescript">  sources: ['wordlist.tsv'],</code></pre>
 
-<p> The fourth line marks the termination of the lexical model source code. If we specify any customizations, they <strong>must</strong> be declared above this line: </p>
+<p> The seventh line marks the termination of the lexical model source code. If we specify any customizations, they <strong>must</strong> be declared above this line: </p>
 <pre><code class="lang-typescript">};</code></pre>
 
-<p> The fifth line is necessary to allow external applications to read the lexical model source code.</p>
+<p> The eighth line is necessary to allow external applications to read the lexical model source code.</p>
 <pre><code class="lang-typescript">export default source;</code></pre>
 
 
-<h2> Customizing a wordlist lexical model </h2>
+<h2> Customizing our lexical model </h2>
 
 <p> The template, as described in the previous section, is a good starting
 point, and may be all you need for you language. However, most language

--- a/developer/14.0/guides/lexical-models/advanced/word-breaker.php
+++ b/developer/14.0/guides/lexical-models/advanced/word-breaker.php
@@ -8,14 +8,6 @@
 
 <h1 class="title"> Word breaker </h1>
 
-<aside>
-  <p>
-    <strong>Note</strong>: If your language uses spaces to denote word breaks,
-    the default word breaker is probably sufficient. Only customize this if you
-    know the default word breaker really does not work for your language!
-  </p>
-</aside>
-
 <p> The <code>trie</code> family of lexical models needs to know what a word
 is in running text. In languages using the Latin script—like, English, French,
 and SENĆOŦEN—finding words is easy. Words are separated by spaces or
@@ -44,7 +36,7 @@ text to determine where the words are. </p>
 
 <h2 id="join">Customize joining rules</h2>
 
-<p>The default word braker is very liberal in what it considers is a word.</p>
+<p>The default word breaker is very liberal in what it considers is a word.</p>
 
 <p>For instance, the default word breaker will split words at hyphens. Consider the following Plains Cree example; this is a single word:</p>
 
@@ -85,6 +77,15 @@ export default source;</code></pre>
 
 
 <h2 id="custom">Writing a custom word breaker function</h2>
+
+<aside>
+  <p>
+    <strong>Note</strong>: If your language uses spaces to denote word breaks,
+    the default word breaker is probably sufficient. Only customize this if you
+    know the default word breaker really does not work for your language!
+  </p>
+</aside>
+
 
 <p> The word breaker function can be specified in the
   <a href="./model-definition-file.php">model definition file</a> as follows:

--- a/developer/14.0/reference/file-types/model-ts.php
+++ b/developer/14.0/reference/file-types/model-ts.php
@@ -66,8 +66,8 @@ quickly. </p>
 Keyman supplies a default algorithm that conforms to the rules expected for many Latin-script
 languages.</p>
 <pre><code class="lang-typescript">  wordBreaker: {
-  use: 'default',
-},</code></pre>
+    use: 'default',
+  },</code></pre>
 
 <p> On the sixth line, we're telling the <code>trie</code> where to find our wordlist. </p>
 <pre><code class="lang-typescript">  sources: ['wordlist.tsv'],</code></pre>

--- a/developer/14.0/reference/file-types/model-ts.php
+++ b/developer/14.0/reference/file-types/model-ts.php
@@ -121,7 +121,7 @@ regardless of things such as <strong>accents</strong>,
 <strong>diacritics</strong>, <strong>lettercase</strong>, and minor
 <strong>spelling variations</strong>.
 The ”regular” form is called the <dfn>key</dfn>.  Typically, the key is always
-in lowercase, and lacks all accents and diacritics. For example, the key form
+in lowercase, and lacks all accents and diacritics. For example, the key
 of “naïve" is "naive" and the key of Canada is “canada”. </p>
 
 <p> The form of the word that is stored is “regularized” through the use of a

--- a/developer/14.0/reference/file-types/model-ts.php
+++ b/developer/14.0/reference/file-types/model-ts.php
@@ -170,3 +170,15 @@ specify one: </p>
 there are cases, such as with SENĆOŦEN, where some characters do not decompose
 into a base letter and a diacritic. In this case, it is necessary to write
 your own key function. </p>
+
+<h2>Version History</h2>
+
+<dl>
+  <dt>Keyman 12</dt>
+  <dd><code>.model.ts</code> file introduced.</dd>
+  <dt>Keyman 14</dt>
+  <dd><code class="lang-typescript">wordBreaker: { 'use': ... }</code>
+  syntax introduced</dd>
+  <dd><code class="lang-typescript">wordBreaker: { 'joinWordsAt': ... }</code>
+  property introduced</dd>
+</dl>

--- a/developer/14.0/reference/file-types/model-ts.php
+++ b/developer/14.0/reference/file-types/model-ts.php
@@ -43,7 +43,9 @@ similar to the following.</p>
 
 const source: LexicalModelSource = {
   format: 'trie-1.0',
-  wordBreaker: 'default',
+  wordBreaker: {
+    use: 'default',
+  },
   sources: ['wordlist.tsv'],
 };
 export default source;</code></pre>
@@ -60,18 +62,20 @@ lexical model such that it can predict through thousands of words very
 quickly. </p>
 <pre><code class="lang-typescript">  format: 'trie-1.0',</code></pre>
 
-<p> On the third line, we're specifying the word breaking algorithm that we want to use.
+<p> On lines 3–5, we're specifying the word breaking algorithm that we want to use.
 Keyman supplies a default algorithm that conforms to the rules expected for many Latin-script
 languages.</p>
-<pre><code class="lang-typescript">  wordBreaker: 'default',</code></pre>
+<pre><code class="lang-typescript">  wordBreaker: {
+  use: 'default',
+},</code></pre>
 
-<p> On the fourth line, we're telling the <code>trie</code> where to find our wordlist. </p>
+<p> On the sixth line, we're telling the <code>trie</code> where to find our wordlist. </p>
 <pre><code class="lang-typescript">  sources: ['wordlist.tsv'],</code></pre>
 
-<p> The fifth line marks the termination of the lexical model source code. If we specify any customizations, they <strong>must</strong> be declared above this line: </p>
+<p> The seventh line marks the termination of the lexical model source code. If we specify any customizations, they <strong>must</strong> be declared above this line: </p>
 <pre><code class="lang-typescript">};</code></pre>
 
-<p> The sixth line is necessary to allow external applications to read the lexical model source code.</p>
+<p> The eighth line is necessary to allow external applications to read the lexical model source code.</p>
 <pre><code class="lang-typescript">export default source;</code></pre>
 
 
@@ -96,6 +100,8 @@ punctuation. The actual rules for where to find words can get quite tricky to
 describe, but Keyman implements the <a href="https://unicode.org/reports/tr29/#Word_Boundaries">
 Unicode Standard Annex #29 §4.1 Default Word Boundary Specification </a>
 which works well for most languages.
+If the default doesn't <em>quite</em> work for your language,
+you can <a href="../../guides/lexical-models/advanced/word-breaker.php#join">tweak it</a>.
 </p>
 
 <p> However, in languages written in other scripts—especially East Asian

--- a/developer/14.0/reference/file-types/model-ts.php
+++ b/developer/14.0/reference/file-types/model-ts.php
@@ -175,10 +175,13 @@ your own key function. </p>
 
 <dl>
   <dt>Keyman 12</dt>
-  <dd><code>.model.ts</code> file introduced.</dd>
+  <dd><strong>Added</strong>: the <code>.model.ts</code> file type.</dd>
+  <dt>Keyman 13</dt>
+  <dd><i>No changes.</i></dd>
   <dt>Keyman 14</dt>
-  <dd><code class="lang-typescript">wordBreaker: { 'use': ... }</code>
-  syntax introduced</dd>
-  <dd><code class="lang-typescript">wordBreaker: { 'joinWordsAt': ... }</code>
-  property introduced</dd>
+  <dd><strong>Added</strong>: an alternative syntax for specifying word breakers:
+  <code class="lang-typescript">wordBreaker: { 'use': ... }</code>.</dd>
+  <dd><strong>Added</strong>: specify which characters should be
+  used to join with word breakers:
+  <code class="lang-typescript">wordBreaker: { 'joinWordsAt': ... }</code>.</dd>
 </dl>

--- a/developer/14.0/reference/file-types/model-ts.php
+++ b/developer/14.0/reference/file-types/model-ts.php
@@ -149,9 +149,9 @@ specify one: </p>
   // This does many things, such as:
   //
   //  - separating characters from their accents/diacritics
-  //      e.g., "ï" -> "i" + "◌̈"
+  //      e.g., "ï" -> "i" + "¨" (U+0308)
   //  - converting lookalike characters to a canonical ("regular") form
-  //      e.g., ";" -> ";" (yes, those are two completely different characters!)
+  //      e.g., ";" -> ";" (yes, those are two completely different characters -- U+037E and U+003B!)
   //  - converting "compatible" characters to their canonical ("regular") form
   //      e.g., "𝔥𝔢𝔩𝔩𝔬" -> "hello"
   let normalizedTerm = lowercasedTerm.normalize('NFKD');
@@ -159,7 +159,7 @@ specify one: </p>
   // Now, using the pattern defined above, replace each accent and diacritic with the
   // empty string. This effectively removes all accents and diacritics!
   //
-  // e.g.,  "i" + "◌̈" -> "i"
+  // e.g.,  "i" + "¨" (U+0308) -> "i"
   let termWithoutDiacritics = normalizedTerm.replace(COMBINING_DIACRITICAL_MARKS, '');
 
   // The resultant key is lowercased, and has no accents or diacritics.


### PR DESCRIPTION
Note: I've made a few identical changes in the 13.0 and 14.0 docs, as they are applicable to both, however, the new syntax for the `wordBreaker` property, and the new default `searchTermToKey()` are only applicable to 14.0.