### PR TITLE
fix: edit page link for kb articles

### DIFF
--- a/_includes/includes/com.keyman.help.editpage.inc.php
+++ b/_includes/includes/com.keyman.help.editpage.inc.php
@@ -47,15 +47,6 @@
         $path = "index";
       }
       return "https://github.com/keymanapp/keyman/edit/master/windows/src/desktop/help/$path.xml";
-
-
-
-      if(!empty($matches[4])) {
-        $path = $matches[2] . "/" . $matches[4];
-      } else {
-        $path = "index";
-      }
-      return "https://github.com/keymanapp/keyman/edit/master/windows/src/desktop/help/$path.xml";
     }
     else {
       // Legacy PHP file

--- a/_includes/includes/com.keyman.help.editpage.inc.php
+++ b/_includes/includes/com.keyman.help.editpage.inc.php
@@ -1,0 +1,64 @@
+<?php
+  namespace com\keyman\help\editpage;
+
+  function getPageUrlForEditLink($self, $id, $file) {
+    $base = "https://github.com/keymanapp/help.keyman.com/edit/master";
+    if($self == '/knowledge-base/index.php' && !empty($id)) {
+      // Knowledge Base Article
+      require_once('includes/com.keyman.help.kb.inc.php');
+      return $base."/knowledge-base/".com\keyman\help\kb\filename_from_id($id);
+    }
+    else if($self == '/_includes/md/mdhost.php') {
+      // Markdown file
+      return $base."/".$file;
+    }
+    else if(preg_match('/^\/products\/desktop\/(\d+\.\d+)\/docs\/(about|advanced|basic|common|context|start|troubleshooting|langsetup|index)(_(.+))?\.php$/',
+      $self, $matches)) {
+      // Keyman Desktop help - work back to source xml file name, with a few tricks.
+
+      if(!empty($matches[4])) {
+        $path = $matches[2] . "/" . $matches[4];
+        // Special cases -- this is not ideal but is okay until we refactor Desktop help
+        $specials = array(
+          "advanced/tsf" => "advanced/text_services_framework",
+          "basic/charactermap" => "basic/toolbox_tasks/charactermap",
+          "basic/config_menu" => "basic/config_tasks/config_menu",
+          "basic/disable_keyboard" => "basic/keyboard_tasks/disable_keyboard",
+          "basic/enable_keyboard" => "basic/keyboard_tasks/enable_keyboard",
+          "basic/fonthelper" => "basic/toolbox_tasks/fonthelper",
+          "basic/hotkeys_tab" => "basic/config_tasks/hotkeys_tab",
+          "basic/keyboards_tab" => "basic/config_tasks/keyboards_tab",
+          "basic/options_tab" => "basic/config_tasks/options_tab",
+          "basic/osk" => "basic/toolbox_tasks/osk",
+          "basic/support_tab" => "basic/config_tasks/support_tab",
+          "basic/toolbox" => "basic/toolbox_tasks/toolbox",
+          "basic/uninstall" => "basic/engine_tasks/uninstall",
+          "basic/uninstall_keyboard" => "basic/keyboard_tasks/uninstall_keyboard",
+          "basic/update" => "basic/engine_tasks/update",
+          "basic/usage" => "basic/toolbox_tasks/usage",
+          "context/character_map" => "context/charactermap",
+          "context/font_helper" => "context/fonthelper",
+          "langsetup/psrtmsofficelanguage" => "context/langsetup/psrtmsofficelanguage",
+          "langsetup/psrtwindowslanguage" => "context/langsetup/psrtwindowslanguage"
+          // note context/langsetup is missing source content so we'll ignore for now.
+        );
+        if(array_key_exists($path, $specials)) $path = $specials[$path];
+      } else {
+        $path = "index";
+      }
+      return "https://github.com/keymanapp/keyman/edit/master/windows/src/desktop/help/$path.xml";
+
+
+
+      if(!empty($matches[4])) {
+        $path = $matches[2] . "/" . $matches[4];
+      } else {
+        $path = "index";
+      }
+      return "https://github.com/keymanapp/keyman/edit/master/windows/src/desktop/help/$path.xml";
+    }
+    else {
+      // Legacy PHP file
+      return $base.$self;
+    }
+  }

--- a/_includes/includes/com.keyman.help.kb.inc.php
+++ b/_includes/includes/com.keyman.help.kb.inc.php
@@ -1,0 +1,16 @@
+<?php
+  namespace com\keyman\help\kb;
+
+  //
+  // Knowledge Base Helper Functions
+  //
+
+  function filename_from_id($id) {
+    $id = intval($id, 10);
+    return sprintf("kb%04.4d.md", $id);
+  }
+
+  function link_from_id($id) {
+    $id = intval($id, 10);
+    return "/kb/$id";
+  }

--- a/_includes/includes/footer.php
+++ b/_includes/includes/footer.php
@@ -1,5 +1,18 @@
 <?php
-
+  function getPageUrlForEditLink() {
+    $base = "https://github.com/keymanapp/help.keyman.com/edit/master";
+    if($_SERVER['PHP_SELF'] == '/knowledge-base/index.php' && !empty($_REQUEST['id'])) {
+      // Knowledge Base Article
+      require_once('includes/com.keyman.help.kb.inc.php');
+      return $base."/knowledge-base/".com\keyman\help\kb\filename_from_id($_REQUEST['id']);
+    }
+    else if($_SERVER['PHP_SELF'] == '/_includes/md/mdhost.php')
+      // Markdown file
+      return $base."/".$_REQUEST['file'];
+    else
+      // Legacy PHP file
+      return $base.$_SERVER['PHP_SELF'];
+  }
 ?>
           </article>
         </div>
@@ -49,7 +62,7 @@
   <div class="footer-tab"><h4><a href='https://community.software.sil.org/c/keyman'>Support</a></h4></div>
 </div>
 <div class="footer-tab-holder" id='footer-tab-edit'>
-  <div class="footer-tab"><h4><a href='https://github.com/keymanapp/help.keyman.com/edit/master<?php if(basename($_SERVER['PHP_SELF']) == 'mdhost.php') echo '/'.$_REQUEST['file']; else echo $_SERVER['PHP_SELF']; ?>' target='_blank'>Edit page</a></h4></div>
+  <div class="footer-tab"><h4><a href='<?php echo getPageUrlForEditLink(); ?>' target='_blank'>Edit page</a></h4></div>
 </div>
 <div id="KeymanWebControl"></div>
 <script src='<?= cdn('js/prism.js')?>'></script>

--- a/_includes/includes/footer.php
+++ b/_includes/includes/footer.php
@@ -1,17 +1,12 @@
 <?php
+  require_once("com.keyman.help.editpage.inc.php");
+
   function getPageUrlForEditLink() {
-    $base = "https://github.com/keymanapp/help.keyman.com/edit/master";
-    if($_SERVER['PHP_SELF'] == '/knowledge-base/index.php' && !empty($_REQUEST['id'])) {
-      // Knowledge Base Article
-      require_once('includes/com.keyman.help.kb.inc.php');
-      return $base."/knowledge-base/".com\keyman\help\kb\filename_from_id($_REQUEST['id']);
-    }
-    else if($_SERVER['PHP_SELF'] == '/_includes/md/mdhost.php')
-      // Markdown file
-      return $base."/".$_REQUEST['file'];
-    else
-      // Legacy PHP file
-      return $base.$_SERVER['PHP_SELF'];
+    return \com\keyman\help\editpage\getPageUrlForEditLink(
+      $_SERVER['PHP_SELF'],
+      isset($_REQUEST['id']) ? $_REQUEST['id'] : '',
+      isset($_REQUEST['file']) ? $_REQUEST['file'] : ''
+    );
   }
 ?>
           </article>

--- a/_includes/tests/com.keyman.help.editpage.test.php
+++ b/_includes/tests/com.keyman.help.editpage.test.php
@@ -1,0 +1,19 @@
+<?php
+  namespace com\keyman\help\editpage\test;
+
+  // TODO: let's work on moving this to a testing framework that we run in unit tests for all PRs in future
+
+  require_once("../includes/com.keyman.help.editpage.inc.php");
+
+  $g = glob("../../products/desktop/13.0/docs/*.php", GLOB_MARK);
+
+  foreach($g as $q) {
+    $q = substr($q, 5); // remove ../../
+    $q = \com\keyman\help\editpage\getPageUrlForEditLink($q, '', '');
+    $s = substr($q, strlen("https://github.com/keymanapp/keyman/edit/master/"));
+    if(!file_exists("c:\\projects\\keyman\\app\\$s")) {
+      // IGNORE: "windows/src/desktop/help/context/langsetup.xml"
+      if($s != "windows/src/desktop/help/context/langsetup.xml")
+        echo "missing: $s\n";
+    }
+  }

--- a/knowledge-base/index.php
+++ b/knowledge-base/index.php
@@ -1,19 +1,13 @@
 <?php
   require_once('includes/ext/parsedown/Parsedown.php');
   require_once('includes/template.php');
+  require_once('includes/com.keyman.help.kb.inc.php');
+
+  use function com\keyman\help\kb\filename_from_id;
+  use function com\keyman\help\kb\link_from_id;
 
   $id = null;
   $title = 'Knowledge Base index';
-
-  function filename_from_id($id) {
-    $id = intval($id, 10);
-    return sprintf("kb%04.4d.md", $id);
-  }
-
-  function link_from_id($id) {
-    $id = intval($id, 10);
-    return "/kb/$id";
-  }
 
   if(isset($_REQUEST['id'])) {
     $id = $_REQUEST['id'];


### PR DESCRIPTION
This also establishes a base namespacing scheme for PHP files to try and give some direction for future patches and changes to websites. `com\keyman\help` will be the long-term base namespace for help.keyman.com, with `com\keyman\help\kb` being the namespace for knowledge base. For now we still need to `require()` the include files because we need to make additional file layout changes for auto require patterns.

Feedback on the design appreciated. See PHP's [weird and wonderful namespace documentation](https://www.php.net/manual/en/language.namespaces.basics.php) for how it's supposed to all work.