### PR TITLE
fix(android): Fix syntax for getLatestKeyboardFileVersion

### DIFF
--- a/developer/engine/android/10.0/KMManager/getLatestKeyboardFileVersion.php
+++ b/developer/engine/android/10.0/KMManager/getLatestKeyboardFileVersion.php
@@ -3,8 +3,10 @@
     $class = 'KMManager';
     $method = 'getLatestKeyboardFileVersion';
     $param1 = 'context';
-    $param2 = 'keyboardID';
-    $methodSyntax = sprintf('<var>%s</var>.%s(<var>Context %s</var>, <var>String %s</var>)', $class, $method, $param1, $param2);
+    $param2 = 'packageID';
+    $param3 = 'keyboardID';
+    $methodSyntax = sprintf('<var>%s</var>.%s(<var>Context %s</var>, <var>String %s</var>, <var>String %s</var>)',
+      $class, $method, $param1, $param2, $param3);
     head(['title' => $class.'.'.$method.'()']);
 ?>
 
@@ -21,6 +23,8 @@
  <dt><code><?php echo $param1 ?></code></dt>
  <dd>The context.</dd>
  <dt><code><?php echo $param2 ?></code></dt>
+ <dd>ID of the package.</dd>
+ <dt><code><?php echo $param3 ?></code></dt>
  <dd>ID of the keyboard.</dd>
 </dl>
 
@@ -28,19 +32,23 @@
 <p>Returns the specified keyboard's latest file version number as <code>String</code> if the keyboard exists, <code>null</code> otherwise.</p>
 
 <h2 id="Description" name="Description">Description</h2>
-<p>Use this method to get the latest file version number of the specified keyboard if it exists in <code>assets/languages/</code> folder.</p>
+<p>Use this method to get the latest file version number of the specified keyboard if it exists in the
+  <code>assets/cloud/</code> or <code>assets/packages/</code> folder.</p>
 
+<p>If packageID is <code>cloud</code>, this method determines the latest file version by the filename.</p>
+
+<p>If packageID is something else, the metadata file assets/packageID/kmp.json is parsed to determine the keyboard version.</p>
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Example:_Using_method” name="Example:_Using_method">Example: Using <code><?php echo $method.'()' ?></code></h3>
+<h3 id="Example:_Using_method" name="Example:_Using_method">Example: Using <code><?php echo $method.'()' ?></code></h3>
 <p>The following script illustrate the use of <code><?php echo $method.'()' ?></code>:</p>
-<pre class="language-javascript line-numbers"><code>    String latestVersion = getLatestKeyboardFileVersion(this, "tamil99m");
+<pre class="language-javascript line-numbers"><code>    String latestVersion = getLatestKeyboardFileVersion(this, "cloud", "tamil99m");
     if (latestVersion != null) {
-        // If we assume that there are 2 tamil99m keyboard files in assets/languages/ folder
+        // If we assume that there are 2 tamil99m keyboard files in assets/cloud/ folder
         // with filenames; tamil99m-1.0.js and tamil99m-1.1.js
         // then latestVersion = "1.1"
     }
     else {
-        // This keyboard does not exist in assets/languages/ folder!
+        // This keyboard does not exist in assets/cloud/ folder!
     }
 </code></pre>

--- a/developer/engine/android/11.0/KMManager/getLatestKeyboardFileVersion.php
+++ b/developer/engine/android/11.0/KMManager/getLatestKeyboardFileVersion.php
@@ -1,11 +1,13 @@
 <?php
-    require_once('includes/template.php');
-    $class = 'KMManager';
-    $method = 'getLatestKeyboardFileVersion';
-    $param1 = 'context';
-    $param2 = 'keyboardID';
-    $methodSyntax = sprintf('<var>%s</var>.%s(<var>Context %s</var>, <var>String %s</var>)', $class, $method, $param1, $param2);
-    head(['title' => $class.'.'.$method.'()']);
+require_once('includes/template.php');
+$class = 'KMManager';
+$method = 'getLatestKeyboardFileVersion';
+$param1 = 'context';
+$param2 = 'packageID';
+$param3 = 'keyboardID';
+$methodSyntax = sprintf('<var>%s</var>.%s(<var>Context %s</var>, <var>String %s</var>, <var>String %s</var>)',
+  $class, $method, $param1, $param2, $param3);
+head(['title' => $class.'.'.$method.'()']);
 ?>
 
 <h1>KMManager.getLatestKeyboardFileVersion()</h1>
@@ -18,29 +20,35 @@
 
 <h3 id="Parameters" name="Parameters">Parameters</h3>
 <dl>
- <dt><code><?php echo $param1 ?></code></dt>
- <dd>The context.</dd>
- <dt><code><?php echo $param2 ?></code></dt>
- <dd>ID of the keyboard.</dd>
+  <dt><code><?php echo $param1 ?></code></dt>
+  <dd>The context.</dd>
+  <dt><code><?php echo $param2 ?></code></dt>
+  <dd>ID of the package.</dd>
+  <dt><code><?php echo $param3 ?></code></dt>
+  <dd>ID of the keyboard.</dd>
 </dl>
 
 <h3 id="Returns" name="Returns">Returns</h3>
 <p>Returns the specified keyboard's latest file version number as <code>String</code> if the keyboard exists, <code>null</code> otherwise.</p>
 
 <h2 id="Description" name="Description">Description</h2>
-<p>Use this method to get the latest file version number of the specified keyboard if it exists in <code>assets/languages/</code> folder.</p>
+<p>Use this method to get the latest file version number of the specified keyboard if it exists in the
+  <code>assets/cloud/</code> or <code>assets/packages/</code> folder.</p>
 
+<p>If packageID is <code>cloud</code>, this method determines the latest file version by the filename.</p>
+
+<p>If packageID is something else, the metadata file assets/packageID/kmp.json is parsed to determine the keyboard version.</p>
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Example:_Using_method” name="Example:_Using_method">Example: Using <code><?php echo $method.'()' ?></code></h3>
+<h3 id="Example:_Using_method" name="Example:_Using_method">Example: Using <code><?php echo $method.'()' ?></code></h3>
 <p>The following script illustrate the use of <code><?php echo $method.'()' ?></code>:</p>
-<pre class="language-javascript line-numbers"><code>    String latestVersion = getLatestKeyboardFileVersion(this, "tamil99m");
+<pre class="language-javascript line-numbers"><code>    String latestVersion = getLatestKeyboardFileVersion(this, "cloud", "tamil99m");
     if (latestVersion != null) {
-        // If we assume that there are 2 tamil99m keyboard files in assets/languages/ folder
+        // If we assume that there are 2 tamil99m keyboard files in assets/cloud/ folder
         // with filenames; tamil99m-1.0.js and tamil99m-1.1.js
         // then latestVersion = "1.1"
     }
     else {
-        // This keyboard does not exist in assets/languages/ folder!
+        // This keyboard does not exist in assets/cloud/ folder!
     }
 </code></pre>

--- a/developer/engine/android/12.0/KMManager/getLatestKeyboardFileVersion.php
+++ b/developer/engine/android/12.0/KMManager/getLatestKeyboardFileVersion.php
@@ -1,11 +1,13 @@
 <?php
-    require_once('includes/template.php');
-    $class = 'KMManager';
-    $method = 'getLatestKeyboardFileVersion';
-    $param1 = 'context';
-    $param2 = 'keyboardID';
-    $methodSyntax = sprintf('<var>%s</var>.%s(<var>Context %s</var>, <var>String %s</var>)', $class, $method, $param1, $param2);
-    head(['title' => $class.'.'.$method.'()']);
+require_once('includes/template.php');
+$class = 'KMManager';
+$method = 'getLatestKeyboardFileVersion';
+$param1 = 'context';
+$param2 = 'packageID';
+$param3 = 'keyboardID';
+$methodSyntax = sprintf('<var>%s</var>.%s(<var>Context %s</var>, <var>String %s</var>, <var>String %s</var>)',
+  $class, $method, $param1, $param2, $param3);
+head(['title' => $class.'.'.$method.'()']);
 ?>
 
 <h1>KMManager.getLatestKeyboardFileVersion()</h1>
@@ -18,29 +20,35 @@
 
 <h3 id="Parameters" name="Parameters">Parameters</h3>
 <dl>
- <dt><code><?php echo $param1 ?></code></dt>
- <dd>The context.</dd>
- <dt><code><?php echo $param2 ?></code></dt>
- <dd>ID of the keyboard.</dd>
+  <dt><code><?php echo $param1 ?></code></dt>
+  <dd>The context.</dd>
+  <dt><code><?php echo $param2 ?></code></dt>
+  <dd>ID of the package.</dd>
+  <dt><code><?php echo $param3 ?></code></dt>
+  <dd>ID of the keyboard.</dd>
 </dl>
 
 <h3 id="Returns" name="Returns">Returns</h3>
 <p>Returns the specified keyboard's latest file version number as <code>String</code> if the keyboard exists, <code>null</code> otherwise.</p>
 
 <h2 id="Description" name="Description">Description</h2>
-<p>Use this method to get the latest file version number of the specified keyboard if it exists in <code>assets/languages/</code> folder.</p>
+<p>Use this method to get the latest file version number of the specified keyboard if it exists in the
+  <code>assets/cloud/</code> or <code>assets/packages/</code> folder.</p>
 
+<p>If packageID is <code>cloud</code>, this method determines the latest file version by the filename.</p>
+
+<p>If packageID is something else, the metadata file assets/packageID/kmp.json is parsed to determine the keyboard version.</p>
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Example:_Using_method" name="Example:_Using_method">Example: Using <code><?php echo $method.'()' ?></code></h3>
 <p>The following script illustrate the use of <code><?php echo $method.'()' ?></code>:</p>
-<pre class="language-javascript line-numbers"><code>    String latestVersion = getLatestKeyboardFileVersion(this, "tamil99m");
+<pre class="language-javascript line-numbers"><code>    String latestVersion = getLatestKeyboardFileVersion(this, "cloud", "tamil99m");
     if (latestVersion != null) {
-        // If we assume that there are 2 tamil99m keyboard files in assets/languages/ folder
+        // If we assume that there are 2 tamil99m keyboard files in assets/cloud/ folder
         // with filenames; tamil99m-1.0.js and tamil99m-1.1.js
         // then latestVersion = "1.1"
     }
     else {
-        // This keyboard does not exist in assets/languages/ folder!
+        // This keyboard does not exist in assets/cloud/ folder!
     }
 </code></pre>

--- a/developer/engine/android/13.0/KMManager/getLatestKeyboardFileVersion.php
+++ b/developer/engine/android/13.0/KMManager/getLatestKeyboardFileVersion.php
@@ -1,11 +1,13 @@
 <?php
-    require_once('includes/template.php');
-    $class = 'KMManager';
-    $method = 'getLatestKeyboardFileVersion';
-    $param1 = 'context';
-    $param2 = 'keyboardID';
-    $methodSyntax = sprintf('<var>%s</var>.%s(<var>Context %s</var>, <var>String %s</var>)', $class, $method, $param1, $param2);
-    head(['title' => $class.'.'.$method.'()']);
+require_once('includes/template.php');
+$class = 'KMManager';
+$method = 'getLatestKeyboardFileVersion';
+$param1 = 'context';
+$param2 = 'packageID';
+$param3 = 'keyboardID';
+$methodSyntax = sprintf('<var>%s</var>.%s(<var>Context %s</var>, <var>String %s</var>, <var>String %s</var>)',
+  $class, $method, $param1, $param2, $param3);
+head(['title' => $class.'.'.$method.'()']);
 ?>
 
 <h1>KMManager.getLatestKeyboardFileVersion()</h1>
@@ -18,29 +20,35 @@
 
 <h3 id="Parameters" name="Parameters">Parameters</h3>
 <dl>
- <dt><code><?php echo $param1 ?></code></dt>
- <dd>The context.</dd>
- <dt><code><?php echo $param2 ?></code></dt>
- <dd>ID of the keyboard.</dd>
+  <dt><code><?php echo $param1 ?></code></dt>
+  <dd>The context.</dd>
+  <dt><code><?php echo $param2 ?></code></dt>
+  <dd>ID of the package.</dd>
+  <dt><code><?php echo $param3 ?></code></dt>
+  <dd>ID of the keyboard.</dd>
 </dl>
 
 <h3 id="Returns" name="Returns">Returns</h3>
 <p>Returns the specified keyboard's latest file version number as <code>String</code> if the keyboard exists, <code>null</code> otherwise.</p>
 
 <h2 id="Description" name="Description">Description</h2>
-<p>Use this method to get the latest file version number of the specified keyboard if it exists in <code>assets/languages/</code> folder.</p>
+<p>Use this method to get the latest file version number of the specified keyboard if it exists in the
+  <code>assets/cloud/</code> or <code>assets/packages/</code> folder.</p>
 
+<p>If packageID is <code>cloud</code>, this method determines the latest file version by the filename.</p>
+
+<p>If packageID is something else, the metadata file assets/packageID/kmp.json is parsed to determine the keyboard version.</p>
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Example:_Using_method" name="Example:_Using_method">Example: Using <code><?php echo $method.'()' ?></code></h3>
 <p>The following script illustrate the use of <code><?php echo $method.'()' ?></code>:</p>
-<pre class="language-javascript line-numbers"><code>    String latestVersion = getLatestKeyboardFileVersion(this, "tamil99m");
+<pre class="language-javascript line-numbers"><code>    String latestVersion = getLatestKeyboardFileVersion(this, "cloud", "tamil99m");
     if (latestVersion != null) {
-        // If we assume that there are 2 tamil99m keyboard files in assets/languages/ folder
+        // If we assume that there are 2 tamil99m keyboard files in assets/cloud/ folder
         // with filenames; tamil99m-1.0.js and tamil99m-1.1.js
         // then latestVersion = "1.1"
     }
     else {
-        // This keyboard does not exist in assets/languages/ folder!
+        // This keyboard does not exist in assets/cloud/ folder!
     }
 </code></pre>


### PR DESCRIPTION
Starting with KMEA 10.0 onward, the syntax for getLatestKeyboardFileVersion() changed from
`getLatestKeyboardFileVersion(Context context, final String keyboardID)` to
`getLatestKeyboardFileVersion(Context context, final String packageID, final String keyboardID)`

This PR fixes:
* documentation to account for packageID
* the description on which paths are analyzed (cloud/ vs packages/)