### PR TITLE
docs: Add page on Android System Requirements

### DIFF
--- a/products/android/14.0/_shared/help_links.php
+++ b/products/android/14.0/_shared/help_links.php
@@ -11,4 +11,5 @@
   <li><a href='uninstalling-dictionaries.php'>Removing a dictionary</a></li>
   <li><a href='using-keyman-browser.php'>Using the Keyman browser</a></li>
   <li><a href='using-settings-screen.php'>Using the Keyman Settings</a></li>
+  <li><a href='system-requirements.php'>System Requirements</a></li>
 </ul>

--- a/products/android/14.0/system-requirements.php
+++ b/products/android/14.0/system-requirements.php
@@ -1,0 +1,37 @@
+<?php
+require_once('includes/template.php');
+require_once('includes/session-embed.php');
+require_once('includes/session-formfactor.php');
+
+head([
+  'title' => 'System Requirements - Keyman for Android Help',
+  'css' => ['template.css', 'app-info-a.css', 'embed.css', 'formfactor.css'],
+  'embedded' => $embed_android
+]);
+?>
+
+<h2>Minimum System Requirements</h2>
+
+<?php
+// We need to condition here.  While CSS selection can affect visibility, it
+// won't prevent offlining scripts from following the links and breaking
+// the desired mirrored content for offline help.
+if(!$embed_android) {
+  formFactorSelect();
+}
+?>
+
+<h3>Minimum Android Version</h3>
+<p>
+  Keyman for Android will run on Android phones and tablets that have a minimum version of
+  <a href='https://developer.android.com/about/versions/lollipop'>Android 5.0 (Lollipop)</a>.
+</p>
+
+<h3>Device Permissions</h3>
+<p>
+  Network and external storage permissions are required to download and install keyboards/dictionaries from the Keyman servers.
+</p>
+
+<?php
+include('./_shared/help_links.php');
+?>


### PR DESCRIPTION
At @MakaraSok 's request, this adds a page about the system requirements to run Keyman for Android

Note, this applies to Keyman 14.0 which raises the minimum Android SDK from 4.4 KitKat to 5.0 Lollipop.

Also, the KMEA content for Keyman 14.0 already lists 
> Android 5.0  and layer versions
