### PR TITLE
fix: current-version breaking some links

### DIFF
--- a/_includes/includes/page-version.php
+++ b/_includes/includes/page-version.php
@@ -71,7 +71,7 @@
           }
         } else {
           if($version == $PageVersion->currentVersion) {
-            $text = "Version $version (current release)";
+            $text = "Version $version (current version)";
             $target = "{$PageVersion->basePath}/current-version/{$PageVersion->subPath}";
           } else {
             $text = "Version $version";
@@ -124,7 +124,7 @@
     /// that overrides, as we may have alpha content that is not yet current.
     ///
     static private function GetCurrentVersion($versions) {
-      $currentVersion = $versions[sizeof($versions)-1];
+      $currentVersion = $versions[0];
 
       $rootwebconfig = @file_get_contents($_SERVER['DOCUMENT_ROOT'] . '/web.config');
       if(preg_match('/current-version:(\d+\.\d+)/', $rootwebconfig, $matches) &&


### PR DESCRIPTION
Relates to #233.

The oldest version was selected instead of the newest version in one place, where other places expected the newest version, leading to broken links appearing on some pages, e.g. developer/cloud/1.0/webapi (note, this was appearing in the `<link rel=canonical>` tag, so not visible on the page).