### PR TITLE
chore: Clarify linux architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/.DS_Store
 .idea/
 cdn/deploy
+vendor/

--- a/products/linux/11.0/common.php
+++ b/products/linux/11.0/common.php
@@ -85,7 +85,7 @@ sudo apt-get install ibus-kmfl</code></pre>
 <p>
   <span class="red">A.</span> Keyman runs on Debian, Ubuntu, Wasta Linux and can be compiled to run from source in most
     distributions.<br/>
-  Note: there's currently a limitation where the Keyman pacakges are incomplete on the Xenial ppa.
+  Note: there's currently a limitation where the Keyman packages are incomplete on the Xenial ppa.
 </p>
 
 <br/>

--- a/products/linux/12.0/common.php
+++ b/products/linux/12.0/common.php
@@ -85,7 +85,7 @@ sudo apt-get install ibus-kmfl</code></pre>
 <p>
   <span class="red">A.</span> Keyman runs on Debian, Ubuntu, Wasta Linux and can be compiled to run from source in most
     distributions.<br/>
-  Note: there's currently a limitation where the Keyman pacakges are incomplete on the Xenial ppa.
+  Note: there's currently a limitation where the Keyman packages are incomplete on the Xenial ppa.
 </p>
 
 <br/>

--- a/products/linux/13.0/common.php
+++ b/products/linux/13.0/common.php
@@ -11,6 +11,16 @@ head([
 <h1 class="red">Common Questions</h1>
 
 <p>
+  <span class="red">Q.</span> What Linux distros will Keyman work with?
+</p>
+<p>
+  <span class="red">A.</span> Keyman is built for amd64 architecture and runs on Debian, Ubuntu, Wasta Linux.
+  It can be compiled to run from source in most distributions.<br/>
+  Note: Keyman packages are unavailable on the Xenial ppa.
+</p>
+
+<br/>
+<p>
   <span class="red">Q.</span> How do I install Keyman for Linux?
 </p>
 <p>
@@ -76,16 +86,6 @@ sudo apt-get install ibus-kmfl</code></pre>
 </p>
 <p>
   <img src="<?php echo cdn("img/linux/120/onboard.png"); ?>" alt="Onboard" />
-</p>
-
-<br/>
-<p>
-  <span class="red">Q.</span> What Linux distros will Keyman work with?
-</p>
-<p>
-  <span class="red">A.</span> Keyman runs on Debian, Ubuntu, Wasta Linux and can be compiled to run from source in most
-    distributions.<br/>
-  Note: there's currently a limitation where the Keyman pacakges are incomplete on the Xenial ppa.
 </p>
 
 <br/>


### PR DESCRIPTION
This mirrors the clarification to the Keyman for Linux architecture done in keymanapp/keyman.com#183

Other notes
* I only bothered fixing the typos in versions 11.0-12.0.
* Updated .gitignore to ignore the /vendor/ folder used on `staging`.