### PR TITLE
chore: Update KMEA KMManager for 14.0

### DIFF
--- a/developer/engine/android/14.0/KMManager/addKeyboard.php
+++ b/developer/engine/android/14.0/KMManager/addKeyboard.php
@@ -54,7 +54,7 @@
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Example:_Using_method" name="Example:_Using_method">Example 1: Using <code><?php echo $method.'()' ?></code></h3>
+<h3 id="Example:_Using_method" name="Example:_Using_method">Example: Using <code><?php echo $method.'()' ?></code></h3>
 <p>The following script illustrate the use of <code><?php echo $method.'()' ?></code>:</p>
 <pre class="language-javascript line-numbers"><code>    // Add a custom keyboard
     Keyboard kbInfo = new Keyboard(
@@ -76,21 +76,6 @@
 
     KMManager.addKeyboard(this, kbInfo);
 </code></pre>
-
-<h3 id="Example:_Using_method" name="Example:_Using_method">Example 2: Using <code><?php echo $method.'()' ?></code> (Deprecated syntax)</h3>
-<p>The following script illustrate the use of <code><?php echo $method.'()' ?></code>:</p>
-<pre class="language-javascript line-numbers"><code>    // Add a custom keyboard
-    HashMap<String, String> kbInfo = new HashMap<String, String>();
-    kbInfo.put(KMManager.KMKey_KeyboardID, "tamil99m");
-    kbInfo.put(KMManager.KMKey_LanguageID, "ta");
-    kbInfo.put(KMManager.KMKey_KeyboardName, "Tamil 99M");
-    kbInfo.put(KMManager.KMKey_LanguageName, "Tamil");
-    kbInfo.put(KMManager.KMKey_KeyboardVersion, "1.1");
-    kbInfo.put(KMManager.KMKey_Font, "aava1.ttf");
-    KMManager.addKeyboard(this, kbInfo);
-
-</code></pre>
-
 
 <h2 id="See_also" name="See_also">See also</h2>
 <ul>

--- a/developer/engine/android/14.0/KMManager/addKeyboard.php
+++ b/developer/engine/android/14.0/KMManager/addKeyboard.php
@@ -77,6 +77,10 @@
     KMManager.addKeyboard(this, kbInfo);
 </code></pre>
 
+<h2 id="History" name="History">History</h2>
+<p>Added syntax using Keyboard type parameter in Keyman Engine for Android 14.0.</p>
+<p>Deprecated syntax using the HashMap&lt;String key, String value&gt; parameter in Keyman Engine for Android 14.0</p>
+
 <h2 id="See_also" name="See_also">See also</h2>
 <ul>
  <li><a href="removeKeyboard.php"><code>removeKeyboard()</code></a></li>

--- a/developer/engine/android/14.0/KMManager/addKeyboard.php
+++ b/developer/engine/android/14.0/KMManager/addKeyboard.php
@@ -59,7 +59,7 @@
 <pre class="language-javascript line-numbers"><code>    // Add a custom keyboard
     Keyboard kbInfo = new Keyboard(
       "basic_kbdtam99", // Package ID - filename of the .kmp file
-      "basic_kbdtam99", // Keyboard ID
+      "basic_kbdtam99", // Keyboard ID - filename of the .js file
       "Tamil 99 Basic", // Keyboard Name
       "ta",             // Language ID
       "Tamil",          // Language Name

--- a/developer/engine/android/14.0/KMManager/addKeyboard.php
+++ b/developer/engine/android/14.0/KMManager/addKeyboard.php
@@ -65,7 +65,7 @@
       "Tamil",          // Language Name
       "1.0",            // Keyboard Version
       null,             // URL to help documentation if available
-      "",               // URL to latest .kmp file
+      null,             // URL to latest .kmp file
       true,             // Boolean to show this is a new keyboard in the keyboard picker
 
       // Font information of the .ttf font to use in KMSample2 (for example "aava1.ttf").

--- a/developer/engine/android/14.0/KMManager/addKeyboard.php
+++ b/developer/engine/android/14.0/KMManager/addKeyboard.php
@@ -4,7 +4,8 @@
     $method = 'addKeyboard';
     $param1 = 'context';
     $param2 = 'keyboardInfo';
-    $methodSyntax = sprintf('<var>%s</var>.%s(<var>Context %s</var>, <var>HashMap&lt;String, String&gt; %s</var>)', $class, $method, $param1, $param2);
+    $methodSyntax1 = sprintf('<var>%s</var>.%s(<var>Context %s</var>, <var>Keyboard %s</var>)', $class, $method, $param1, $param2);
+    $methodSyntax2 = sprintf('<var>%s</var>.%s(<var>Context %s</var>, <var>HashMap&lt;String, String&gt; %s</var>)', $class, $method, $param1, $param2);
     head(['title' => $class.'.'.$method.'()']);
 ?>
 
@@ -14,7 +15,26 @@
 <p>The <code><strong><?php echo $method.'()' ?></strong></code> method adds a keyboard into the keyboards list.</p>
 
 <h2 id="Syntax" name="Syntax">Syntax</h2>
-<pre class="language-javascript"><code><?php echo $methodSyntax ?></code></pre>
+<pre class="language-javascript"><code><?php echo $methodSyntax1 ?></code></pre>
+
+<h3 id="Parameters" name="Parameters">Parameters</h3>
+<dl>
+  <dt><code><?php echo $param1 ?></code></dt>
+  <dd>The context.</dd>
+  <dt><code><?php echo $param2 ?></code></dt>
+  <dd>A <code>Keyboard</code> type of keyboard information.</dd>
+</dl>
+
+<h3 id="Returns" name="Returns">Returns</h3>
+<p>Returns <code>true</code> if the keyboard was added successfully, <code>false</code> otherwise.</p>
+
+<h2 id="Description" name="Description">Description</h2>
+<p>Use this method to include a keyboard in the keyboards list so that it can be selected from the keyboards menu. If the keyboard with same keyboard ID and language ID exists, it updates the existing keyboard info.</p>
+
+<br><hr>
+
+<h2 id="Syntax" name="Syntax">Syntax (Deprecated)</h2>
+<pre class="language-javascript"><code><?php echo $methodSyntax2 ?></code></pre>
 
 <h3 id="Parameters" name="Parameters">Parameters</h3>
 <dl>
@@ -30,12 +50,37 @@
 <h2 id="Description" name="Description">Description</h2>
 <p>Use this method to include a keyboard in the keyboards list so that it can be selected from the keyboards menu. If the keyboard with same keyboard ID and language ID exists, it updates the existing keyboard info.</p>
 
+<br><hr>
+
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Example:_Using_method" name="Example:_Using_method">Example: Using <code><?php echo $method.'()' ?></code></h3>
+<h3 id="Example:_Using_method" name="Example:_Using_method">Example 1: Using <code><?php echo $method.'()' ?></code></h3>
 <p>The following script illustrate the use of <code><?php echo $method.'()' ?></code>:</p>
 <pre class="language-javascript line-numbers"><code>    // Add a custom keyboard
-    HashMap&lt;String, String&gt; kbInfo = new HashMap&lt;String, String&gt;();
+    Keyboard kbInfo = new Keyboard(
+      "basic_kbdtam99", // Package ID - filename of the .kmp file
+      "basic_kbdtam99", // Keyboard ID
+      "Tamil 99 Basic", // Keyboard Name
+      "ta",             // Language ID
+      "Tamil",          // Language Name
+      "1.0",            // Keyboard Version
+      null,             // URL to help documentation if available
+      "",               // URL to latest .kmp file
+      true,             // Boolean to show this is a new keyboard in the keyboard picker
+
+      // Font information of the .ttf font to use in KMSample2 (for example "aava1.ttf").
+      // basic_kbdtam99 doesn't include a font. Can set blank "" or KMManager.KMDefault_KeyboardFont
+      // KMEA will use the font for the OSK, but the Android device determines the system font used for keyboard output
+      KMManager.KMDefault_KeyboardFont,  // Font for KMSample2
+      KMManager.KMDefault_KeyboardFont); // Font for OSK
+
+    KMManager.addKeyboard(this, kbInfo);
+</code></pre>
+
+<h3 id="Example:_Using_method" name="Example:_Using_method">Example 2: Using <code><?php echo $method.'()' ?></code> (Deprecated syntax)</h3>
+<p>The following script illustrate the use of <code><?php echo $method.'()' ?></code>:</p>
+<pre class="language-javascript line-numbers"><code>    // Add a custom keyboard
+    HashMap<String, String> kbInfo = new HashMap<String, String>();
     kbInfo.put(KMManager.KMKey_KeyboardID, "tamil99m");
     kbInfo.put(KMManager.KMKey_LanguageID, "ta");
     kbInfo.put(KMManager.KMKey_KeyboardName, "Tamil 99M");
@@ -43,7 +88,9 @@
     kbInfo.put(KMManager.KMKey_KeyboardVersion, "1.1");
     kbInfo.put(KMManager.KMKey_Font, "aava1.ttf");
     KMManager.addKeyboard(this, kbInfo);
+
 </code></pre>
+
 
 <h2 id="See_also" name="See_also">See also</h2>
 <ul>

--- a/developer/engine/android/14.0/KMManager/getCurrentKeyboardInfo.php
+++ b/developer/engine/android/14.0/KMManager/getCurrentKeyboardInfo.php
@@ -39,7 +39,7 @@
 </dl>
 
 <h3 id="Returns" name="Returns">Returns</h3>
-<p>Returns an information dictionary of the current keyboard with keys and values defined as <code>HashMap&lt;String key, String value&gt;</code>.</p>
+<p>(Deprecated) Returns an information dictionary of the current keyboard with keys and values defined as <code>HashMap&lt;String key, String value&gt;</code>.</p>
 
 <h2 id="Description" name="Description">Description</h2>
 <p>Use this method to get details of the currently selected keyboard. Details include keyboard ID, language ID, keyboard name, language name and fonts.</p>

--- a/developer/engine/android/14.0/KMManager/getCurrentKeyboardInfo.php
+++ b/developer/engine/android/14.0/KMManager/getCurrentKeyboardInfo.php
@@ -10,7 +10,7 @@
 <h1>KMManager.getCurrentKeyboardInfo()</h1>
 
 <h2 id="Summary" name="Summary">Summary</h2>
-<p>The <code><strong><?php echo $method.'()' ?></strong></code> method returns information dictionary of the current keyboard.</p>
+<p>The <code><strong><?php echo $method.'()' ?></strong></code> method returns keyboard information of the current keyboard.</p>
 
 <h2 id="Syntax" name="Syntax">Syntax</h2>
 <pre class="language-javascript"><code><?php echo $methodSyntax ?></code></pre>
@@ -22,23 +22,44 @@
 </dl>
 
 <h3 id="Returns" name="Returns">Returns</h3>
+<p>Returns the current keyboard information of <code>Keyboard</code> type.</p>
+
+<h2 id="Description" name="Description">Description</h2>
+<p>Use this method to get details of the currently selected keyboard. Details include package ID, keyboard ID, language ID, keyboard name, language name and fonts.</p>
+
+<br><hr>
+
+<h2 id="Syntax" name="Syntax">Syntax (Deprecated)</h2>
+<pre class="language-javascript"><code><?php echo $methodSyntax ?></code></pre>
+
+<h3 id="Parameters" name="Parameters">Parameters</h3>
+<dl>
+  <dt><code><?php echo $param1 ?></code></dt>
+  <dd>The context.</dd>
+</dl>
+
+<h3 id="Returns" name="Returns">Returns</h3>
 <p>Returns an information dictionary of the current keyboard with keys and values defined as <code>HashMap&lt;String key, String value&gt;</code>.</p>
 
 <h2 id="Description" name="Description">Description</h2>
 <p>Use this method to get details of the currently selected keyboard. Details include keyboard ID, language ID, keyboard name, language name and fonts.</p>
 
+<br><hr>
+
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Example:_Using_method" name="Example:_Using_method">Example: Using <code><?php echo $method.'()' ?></code></h3>
 <p>The following script illustrate the use of <code><?php echo $method.'()' ?></code>:</p>
-<pre class="language-javascript line-numbers"><code>    HashMap&lt;String, String&gt; keyboardInfo = KMManager.getCurrentKeyboardInfo(this);
+<pre class="language-javascript line-numbers"><code>    Keyboard keyboardInfo = KMManager.getCurrentKeyboardInfo(this);
     if (keyboardInfo != null) {
-        String keyboardId = keyboardInfo.get(KMManager.KMKey_KeyboardID);
-        String languageId = keyboardInfo.get(KMManager.KMKey_LanguageID);
-        String keyboardName = keyboardInfo.get(KMManager.KMKey_KeyboardName);
-        String languageName = keyboardInfo.get(KMManager.KMKey_LanguageName);
-        String font = keyboardInfo.get(KMManager.KMKey_Font);
-        String oskFont = keyboardInfo.get(KMManager.KMKey_OskFont);
+        String packageID = keyboardInfo.getPackageID();
+        String keyboardId = keyboardInfo.getKeyboardID();
+        String keyboardName = keyboardInfo.getKeyboardName();
+        String languageId = keyboardInfo.getLanguageID();
+        String languageName = keyboardInfo.getLanguageName();
+        String version = keyboardInfo.getVersion();
+        String font = keyboardInfo.getFont();
+        String oskFont = keyboardInfo.getOSKFont();
         //
     }
 </code></pre>

--- a/developer/engine/android/14.0/KMManager/getCurrentKeyboardInfo.php
+++ b/developer/engine/android/14.0/KMManager/getCurrentKeyboardInfo.php
@@ -64,6 +64,10 @@
     }
 </code></pre>
 
+<h2 id="History" name="History">History</h2>
+<p>Added syntax for returning Keyboard type in Keyman Engine for Android 14.0.</p>
+<p>Deprecated syntax for returning HashMap&lt;String key, String value&gt; in Keyman Engine for Android 14.0</p>
+
 <h2 id="See_also" name="See_also">See also</h2>
 <ul>
  <li><a href="getCurrentKeyboardIndex.php"><code>getCurrentKeyboardIndex()</code></a></li>

--- a/developer/engine/android/14.0/KMManager/getDefaultKeyboard.md
+++ b/developer/engine/android/14.0/KMManager/getDefaultKeyboard.md
@@ -1,0 +1,29 @@
+---
+title: KMManager.getDefaultKeyboard()
+---
+
+## Summary
+The **getDefaultKeyboard()** method returns the keyboard information for the fallback keyboard.
+
+## Syntax
+```java
+KMManager.getDefaultKeyboard()
+```
+
+## Returns
+Returns `Keyboard` type for the fallback keyboard. If not specified, this defaults to keyboard information for sil_euro_latin.
+
+## Description
+The **getDefaultKeyboard()** method returns the keyboard information for the fallback keyboard. If Keyman Engine
+has issues with a current keyboard, KMManager will switch to this fallback keyboard.
+
+## Examples
+
+### Example: Using getDefaultKeyboard()
+The following script illustrates the use of `getDefaultKeyboard()`: 
+```java
+    Keyboard kbd = KMManager.getDefaultKeyboard();
+```
+
+## See also
+* [setDefaultKeyboard](setDefaultKeyboard)

--- a/developer/engine/android/14.0/KMManager/getDefaultKeyboard.md
+++ b/developer/engine/android/14.0/KMManager/getDefaultKeyboard.md
@@ -3,7 +3,7 @@ title: KMManager.getDefaultKeyboard()
 ---
 
 ## Summary
-The **getDefaultKeyboard()** method returns the keyboard information for the fallback keyboard.
+The `getDefaultKeyboard()` method returns the keyboard information for the fallback keyboard.
 
 ## Syntax
 ```java
@@ -14,7 +14,7 @@ KMManager.getDefaultKeyboard()
 Returns `Keyboard` type for the fallback keyboard. If not specified, this defaults to keyboard information for sil_euro_latin.
 
 ## Description
-The **getDefaultKeyboard()** method returns the keyboard information for the fallback keyboard. If Keyman Engine
+The `getDefaultKeyboard()` method returns the keyboard information for the fallback keyboard. If Keyman Engine
 has issues with a current keyboard, KMManager will switch to this fallback keyboard.
 
 ## Examples

--- a/developer/engine/android/14.0/KMManager/getDefaultKeyboard.php
+++ b/developer/engine/android/14.0/KMManager/getDefaultKeyboard.php
@@ -32,6 +32,9 @@
     KMManager.setKeyboard(kbd);
 </code></pre>
 
+<h2 id="History" name="History">History</h2>
+<p>Added syntax in Keyman Engine for Android 14.0.</p>
+
 <h2 id="See_also" name="See_also">See also</h2>
 <ul>
  <li><a href="setDefaultKeyboard.php" title="Title."><code>setDefaultKeyboard()</code></a></li>

--- a/developer/engine/android/14.0/KMManager/getKeyboardInfo.php
+++ b/developer/engine/android/14.0/KMManager/getKeyboardInfo.php
@@ -27,6 +27,22 @@
 <h3 id="Returns" name="Returns">Returns</h3>
 <p>Returns an information <code>Keyboard</code> type of the specified keyboard.</p>
 
+<h2 id="Description" name="Description">Description</h2>
+<p>Use this method to get details of the keyboard at given position in keyboards list. Details include keyboard ID, language ID, keyboard name, language name and fonts.</p>
+
+<br><hr>
+
+<h2 id="Syntax" name="Syntax">Syntax (Deprecated)</h2>
+<pre class="language-javascript"><code><?php echo $methodSyntax ?></code></pre>
+
+<h3 id="Parameters" name="Parameters">Parameters</h3>
+<dl>
+  <dt><code><?php echo $param1 ?></code></dt>
+  <dd>The context.</dd>
+  <dt><code><?php echo $param2 ?></code></dt>
+  <dd>0-based position of the keyboard in keyboards list.</dd>
+</dl>
+
 <h3 id="Returns" name="Returns">Returns</h3>
 <p>(Deprecated) Returns an information dictionary of the specified keyboard with keys and values defined as <code>HashMap&lt;String key, String value&gt;</code>.</p>
 

--- a/developer/engine/android/14.0/KMManager/getKeyboardInfo.php
+++ b/developer/engine/android/14.0/KMManager/getKeyboardInfo.php
@@ -11,7 +11,7 @@
 <h1>KMManager.getKeyboardInfo()</h1>
 
 <h2 id="Summary" name="Summary">Summary</h2>
-<p>The <code><strong><?php echo $method.'()' ?></strong></code> method returns information dictionary of the specified keyboard.</p>
+<p>The <code><strong><?php echo $method.'()' ?></strong></code> method returns information of the specified keyboard.</p>
 
 <h2 id="Syntax" name="Syntax">Syntax</h2>
 <pre class="language-javascript"><code><?php echo $methodSyntax ?></code></pre>
@@ -25,7 +25,10 @@
 </dl>
 
 <h3 id="Returns" name="Returns">Returns</h3>
-<p>Returns an information dictionary of the specified keyboard with keys and values defined as <code>HashMap&lt;String key, String value&gt;</code>.</p>
+<p>Returns an information <code>Keyboard</code> type of the specified keyboard.</p>
+
+<h3 id="Returns" name="Returns">Returns</h3>
+<p>(Deprecated) Returns an information dictionary of the specified keyboard with keys and values defined as <code>HashMap&lt;String key, String value&gt;</code>.</p>
 
 <h2 id="Description" name="Description">Description</h2>
 <p>Use this method to get details of the keyboard at given position in keyboards list. Details include keyboard ID, language ID, keyboard name, language name and fonts.</p>
@@ -34,14 +37,16 @@
 
 <h3 id="Example:_Using_method" name="Example:_Using_method">Example: Using <code><?php echo $method.'()' ?></code></h3>
 <p>The following script illustrate the use of <code><?php echo $method.'()' ?></code>:</p>
-<pre class="language-javascript line-numbers"><code>    HashMap&lt;String, String&gt; keyboardInfo = KMManager.getKeyboardInfo(this, 1);
+<pre class="language-javascript line-numbers"><code>    Keyboard keyboardInfo = KMManager.getKeyboardInfo(this, 1);
     if (keyboardInfo != null) {
-        String keyboardId = keyboardInfo.get(KMManager.KMKey_KeyboardID);
-        String languageId = keyboardInfo.get(KMManager.KMKey_LanguageID);
-        String keyboardName = keyboardInfo.get(KMManager.KMKey_KeyboardName);
-        String languageName = keyboardInfo.get(KMManager.KMKey_LanguageName);
-        String font = keyboardInfo.get(KMManager.KMKey_Font);
-        String oskFont = keyboardInfo.get(KMManager.KMKey_OskFont);
+        String packageID = keyboardInfo.getPackageID();
+        String keyboardId = keyboardInfo.getKeyboardID();
+        String keyboardName = keyboardInfo.getKeyboardName();
+        String languageId = keyboardInfo.getLanguageID();
+        String languageName = keyboardInfo.getLanguageName();
+        String version = keyboardInfo.getVersion();
+        String font = keyboardInfo.getFont();
+        String oskFont = keyboardInfo.getOSKFont();
         //
     }
 </code></pre>

--- a/developer/engine/android/14.0/KMManager/getKeyboardInfo.php
+++ b/developer/engine/android/14.0/KMManager/getKeyboardInfo.php
@@ -67,6 +67,10 @@
     }
 </code></pre>
 
+<h2 id="History" name="History">History</h2>
+<p>Added syntax for returning Keyboard type in Keyman Engine for Android 14.0.</p>
+<p>Deprecated syntax for returning the HashMap&lt;String key, String value&gt; in Keyman Engine for Android 14.0</p>
+
 <h2 id="See_also" name="See_also">See also</h2>
 <ul>
  <li><a href="getCurrentKeyboardIndex.php"><code>getCurrentKeyboardIndex()</code></a></li>

--- a/developer/engine/android/14.0/KMManager/getKeyboardsList.php
+++ b/developer/engine/android/14.0/KMManager/getKeyboardsList.php
@@ -39,7 +39,7 @@
 </dl>
 
 <h3 id="Returns" name="Returns">Returns</h3>
-<p>Returns keyboards list as <code>ArrayList&lt;HashMap&lt;String key, String value&gt;&gt;</code> if it exists, <code>null</code> otherwise.</p>
+<p>(Deprecated) Returns keyboards list as <code>ArrayList&lt;HashMap&lt;String key, String value&gt;&gt;</code> if it exists, <code>null</code> otherwise.</p>
 
 <h2 id="Description" name="Description">Description</h2>
 <p>Use this method to get details of all keyboard's in keyboards menu.</p>

--- a/developer/engine/android/14.0/KMManager/getKeyboardsList.php
+++ b/developer/engine/android/14.0/KMManager/getKeyboardsList.php
@@ -58,6 +58,11 @@
     }
 </code></pre>
 
+<h2 id="History" name="History">History</h2>
+
+<p>Added syntax for returning list of Keyboard type in Keyman Engine for Android 14.0.</p>
+<p>Deprecated syntax for returning the list of HashMap&lt;String key, String value&gt; in Keyman Engine for Android 14.0</p>
+
 <h2 id="See_also" name="See_also">See also</h2>
 <ul>
  <li><a href="getCurrentKeyboardIndex.php"><code>getCurrentKeyboardIndex()</code></a></li>

--- a/developer/engine/android/14.0/KMManager/getKeyboardsList.php
+++ b/developer/engine/android/14.0/KMManager/getKeyboardsList.php
@@ -10,7 +10,7 @@
 <h1>KMManager.getKeyboardsList()</h1>
 
 <h2 id="Summary" name="Summary">Summary</h2>
-<p>The <code><strong><?php echo $method.'()' ?></strong></code> method returns the array of keyboards list.</p>
+<p>The <code><strong><?php echo $method.'()' ?></strong></code> method returns the keyboards list.</p>
 
 <h2 id="Syntax" name="Syntax">Syntax</h2>
 <pre class="language-javascript"><code><?php echo $methodSyntax ?></code></pre>
@@ -22,28 +22,39 @@
 </dl>
 
 <h3 id="Returns" name="Returns">Returns</h3>
+<p>Returns keyboards list as <code>List&lt;Keyboard&gt;</code> if it exists, <code>null</code> otherwise.</p>
+
+<h2 id="Description" name="Description">Description</h2>
+<p>Use this method to get details of all keyboard's in keyboards menu.</p>
+
+<br><hr>
+
+<h2 id="Syntax" name="Syntax">Syntax (Deprecated)</h2>
+<pre class="language-javascript"><code><?php echo $methodSyntax ?></code></pre>
+
+<h3 id="Parameters" name="Parameters">Parameters</h3>
+<dl>
+  <dt><code><?php echo $param1 ?></code></dt>
+  <dd>The context.</dd>
+</dl>
+
+<h3 id="Returns" name="Returns">Returns</h3>
 <p>Returns keyboards list as <code>ArrayList&lt;HashMap&lt;String key, String value&gt;&gt;</code> if it exists, <code>null</code> otherwise.</p>
 
 <h2 id="Description" name="Description">Description</h2>
 <p>Use this method to get details of all keyboard's in keyboards menu.</p>
 
+<br><hr>
+
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Example:_Using_method" name="Example:_Using_method">Example: Using <code><?php echo $method.'()' ?></code></h3>
 <p>The following script illustrate the use of <code><?php echo $method.'()' ?></code>:</p>
-<pre class="language-javascript line-numbers"><code>    ArrayList&lt;HashMap&lt;String, String&gt;&gt; keyboardsList = KMManager.getKeyboardsList(this);
-    if (keyboardsList != null) {
-        int length = keyboardsList.size();
-        for (int i = 0; i < length; i++) {
-            HashMap&lt;String, String&gt; keyboardInfo = keyboardsList.get(i);
-            String keyboardId = keyboardInfo.get(KMManager.KMKey_KeyboardID);
-            String languageId = keyboardInfo.get(KMManager.KMKey_LanguageID);
-            String keyboardName = keyboardInfo.get(KMManager.KMKey_KeyboardName);
-            String languageName = keyboardInfo.get(KMManager.KMKey_LanguageName);
-            String font = keyboardInfo.get(KMManager.KMKey_Font);
-            String oskFont = keyboardInfo.get(KMManager.KMKey_OskFont);
-            //
-        }
+<pre class="language-javascript line-numbers"><code>    List&lt;Keyboard&gt; keyboardsList = KMManager.getKeyboardsList(this);
+    if ((keyboardsList != null) && keyboardsList.size() < 2) {
+        // Add another Keyboard
+        Keyboard kbd = new Keyboard(...);
+        KMManager.addKeyboard(kbd);
     }
 </code></pre>
 

--- a/developer/engine/android/14.0/KMManager/getMaySendCrashReport.md
+++ b/developer/engine/android/14.0/KMManager/getMaySendCrashReport.md
@@ -1,0 +1,30 @@
+---
+title: KMManager.getMaySendCrashReport()
+---
+
+## Summary
+The **getMaySendCrashReport()** method returns whether Keyman Engine is allowed to send crash reports over the network to sentry.keyman.com.
+
+## Syntax
+```java
+KMManager.getMaySendCrashReport()
+```
+
+## Returns
+Returns `true` if crash reports can be sent over the network to sentry.keyman.com, `false` otherwise.
+
+## Description
+Use this method to check if Keyman Engine will be accessing the network to send crash reports.
+
+## Examples
+
+### Example: Using getMaySendCrashReport()
+The following script illustrates the use of `getMaySendCrashReport()`: 
+```java
+    if (KMManager.getMaySendCrashReport()) {
+        // do something
+    } 
+```
+
+## See also
+* [setMaySendCrashReport](setMaySendCrashReport)

--- a/developer/engine/android/14.0/KMManager/getMaySendCrashReport.md
+++ b/developer/engine/android/14.0/KMManager/getMaySendCrashReport.md
@@ -16,15 +16,8 @@ Returns `true` if crash reports can be sent over the network to sentry.keyman.co
 ## Description
 Use this method to check if Keyman Engine will be accessing the network to send crash reports.
 
-## Examples
-
-### Example: Using getMaySendCrashReport()
-The following script illustrates the use of `getMaySendCrashReport()`: 
-```java
-    if (KMManager.getMaySendCrashReport()) {
-        // do something
-    } 
-```
+## History
+Added syntax in Keyman Engine for Android 14.0.
 
 ## See also
 * [setMaySendCrashReport](setMaySendCrashReport)

--- a/developer/engine/android/14.0/KMManager/index.php
+++ b/developer/engine/android/14.0/KMManager/index.php
@@ -121,6 +121,9 @@
   <dt><code>getLexicalModelsList()</code></dt>
   <dd>returns the array of lexical models list</dd>
 
+  <dt><code><a href='getMaySendCrashReport'>getMaySendCrashReport()</a></code></dt>
+  <dd>returns whether Keyman Engine is allowed to send crash reports over the network to sentry.keyman.com</dd>
+
   <dt><code><a href='getVersion.php'>getVersion()</a></code></dt>
   <dd>returns the version number of Keyman Engine</dd>
 
@@ -201,6 +204,9 @@
 
   <dt><code><strike>setKeymanLicense() (Deprecated)</strike></code></dt>
   <dd>sets the developer license/key pair to unlock Keyman Engine</dd>
+
+  <dt><code><a href='setMaySendCrashReport'>setMaySendCrashReport()</a></code></dt>
+  <dd>sets whether Keyman Engine can send crash reports over the network to sentry.keyman.com</dd>
 
   <dt><code><a href='setShouldAllowSetKeyboard.php'>setShouldAllowSetKeyboard()</a></code></dt>
   <dd>sets whether Keyman Engine allows setting a keyboard other than the default keyboard</dd>

--- a/developer/engine/android/14.0/KMManager/index.php
+++ b/developer/engine/android/14.0/KMManager/index.php
@@ -68,7 +68,7 @@
   <dd>returns information dictionary of the current keyboard</dd>
 
   <dt><code><a href='getDefaultKeyboard.php'>getDefaultKeyboard()</a></code></dt>
-  <dd>returns the default fallback keyboard if none have been added</dd>
+  <dd>returns the keyboard information for the fallback keyboard</dd>
 
   <dt><code><a href='getFontTypeface.php'>getFontTypeface()</a></code></dt>
   <dd>creates a new typeface from the specified font filename</dd>
@@ -188,7 +188,7 @@
   <dd>enables or disables debugging of Keyman Engine</dd>
 
   <dt><code><a href='setDefaultKeyboard.php'>setDefaultKeyboard()</a></code></dt>
-  <dd>sets the default fallback keyboard to use if none have been added</dd>
+  <dd>sets the keyboard information for the fallback keyboard</dd>
 
   <dt><code><a href='setGlobeKeyAction.php'>setGlobeKeyAction()</a></code></dt>
   <dd>sets an action type for the 'Globe' key</dd>

--- a/developer/engine/android/14.0/KMManager/setDefaultKeyboard.md
+++ b/developer/engine/android/14.0/KMManager/setDefaultKeyboard.md
@@ -1,0 +1,52 @@
+---
+title: KMManager.setDefaultKeyboard()
+---
+
+## Summary
+The **setDefaultKeyboard()** method sets the keyboard information for the fallback keyboard.
+
+## Syntax
+```java
+KMManager.setDefaultKeyboard(Keyboard keyboardInfo)
+```
+
+### Parameters
+keyboardInfo
+
+The keyboard information for the default keyboard.
+
+## Description
+The **setDefaultKeyboard()** method sets the keyboard information for the fallback keyboard. If Keyman Engine
+has issues with a current keyboard, KMManager will switch to this fallback keyboard.
+
+A fallback keyboard should also be defined if an app doesn't automatically add a keyboard (requires user selection).
+
+**setDefaultKeyboard** should be called after KMManager.initialize().
+
+## Examples
+
+### Example: Using setDefaultKeyboard()
+The following script illustrates the use of `setDefaultKeyboard()`: 
+```java
+    KMManager.initialize(getApplicationContext(), KMManager.KeyboardType.KEYBOARD_TYPE_INAPP);
+
+    // Set the default (fallback) keyboard if this app doesn't automatically call addKeyboard().
+    KMManager.setDefaultKeyboard(
+        new Keyboard(
+            "basic_kbdtam99", // Package ID - filename of the .kmp file
+            "basic_kbdtam99", // Keyboard ID
+            "Tamil 99 Basic", // Keyboard Name
+            "ta",             // Language ID
+            "Tamil",          // Language Name
+            "1.0",            // Keyboard Version
+            null,             // URL to help documentation if available
+            "",               // URL to latest .kmp file
+            true,             // Boolean to show this is a new keyboard in the keyboard picker
+    
+            KMManager.KMDefault_KeyboardFont,  // Font for the keyboard 
+            KMManager.KMDefault_KeyboardFont)  // Font for OSK
+    );
+```
+
+## See also
+* [getDefaultKeyboard](getDefaultKeyboard)

--- a/developer/engine/android/14.0/KMManager/setDefaultKeyboard.md
+++ b/developer/engine/android/14.0/KMManager/setDefaultKeyboard.md
@@ -48,5 +48,8 @@ The following script illustrates the use of `setDefaultKeyboard()`:
     );
 ```
 
+## History
+Added syntax in Keyman Engine for Android 14.0.
+
 ## See also
 * [getDefaultKeyboard](getDefaultKeyboard)

--- a/developer/engine/android/14.0/KMManager/setKeyboard.php
+++ b/developer/engine/android/14.0/KMManager/setKeyboard.php
@@ -8,11 +8,15 @@
     $param4 = 'languageName';
     $param5 = 'kFont';
     $param6 = 'kOskFont';
+    $param7 = 'packageID';
+    $param8 = 'keyboardInfo';
     $param11 = 'context';
     $param22 = 'position';
-    $methodSyntax1 = sprintf('<var>%s</var>.%s(<var>String %s</var>, <var>String %s</var>)', $class, $method, $param1, $param2);
-    $methodSyntax2 = sprintf('<var>%s</var>.%s(<var>String %s</var>, <var>String %s</var>, <var>String %s</var>, <var>String %s</var>, <var>String %s</var>, <var>String %s</var>)', $class, $method, $param1, $param2, $param3, $param4, $param5, $param6);
-    $methodSyntax3 = sprintf('<var>%s</var>.%s(<var>Context %s</var>, <var>int %s</var>)', $class, $method, $param11, $param22);
+    $methodSyntax1 = sprintf('<var>%s</var>.%s(<var>Context %s</var>, </var><var>Keyboard %s</var>)', $class, $method, $param11, $param8);
+    $methodSyntax2 = sprintf('<var>%s</var>.%s(<var>String %s</var>, </var><var>String %s</var>, <var>String %s</var>)', $class, $method, $param7, $param1, $param2);
+    $methodSyntax3 = sprintf('<var>%s</var>.%s(<var>String %s</var>, <var>String %s</var>, <var>String %s</var>, <var>String %s</var>, <var>String %s</var>, <var>String %s</var>, <var>String %s</var>)',
+        $class, $method, $param7, $param1, $param2, $param3, $param4, $param5, $param6);
+    $methodSyntax4 = sprintf('<var>%s</var>.%s(<var>Context %s</var>, <var>int %s</var>)', $class, $method, $param11, $param22);
     head(['title' => $class.'.'.$method.'()']);
 ?>
 
@@ -26,18 +30,17 @@
 
 <h3 id="Parameters" name="Parameters">Parameters</h3>
 <dl>
- <dt><code><?php echo $param1 ?></code></dt>
- <dd>ID of the keyboard.</dd>
-<dt><code><?php echo $param2 ?></code></dt>
-<dd>ID of the associated language.</dd>
+  <dt><code><?php echo $param11 ?></code></dt>
+  <dd>The context.</dd>
+  <dt><code><?php echo $param8 ?></code></dt>
+  <dd>Keyboard type of the keyboard information.</dd>
 </dl>
 
 <h3 id="Returns" name="Returns">Returns</h3>
 <p>Returns <code>true</code> if the keyboard was set successfully, <code>false</code> otherwise.</p>
 
 <h2 id="Description" name="Description">Description</h2>
-<p>This syntax can be used for setting a keyboard which is available on the Keyman server.
-</p>
+<p>Use this syntax to set a keyboard which has already been added into the keyboards list.</p>
 
 <br><hr>
 
@@ -46,30 +49,53 @@
 
 <h3 id="Parameters" name="Parameters">Parameters</h3>
 <dl>
-<dt><code><?php echo $param1 ?></code></dt>
-<dd>ID of the keyboard.</dd>
-<dt><code><?php echo $param2 ?></code></dt>
-<dd>ID of the associated language.</dd>
-<dt><code><?php echo $param3 ?></code></dt>
-<dd>Name of the keyboard.</dd>
-<dt><code><?php echo $param4 ?></code></dt>
-<dd>Name of the associated language.</dd>
-<dt><code><?php echo $param5 ?></code></dt>
-<dd>Filename or description of the font to type with the keyboard. Can be <code>null</code> or empty string.</dd>
-<dt><code><?php echo $param6 ?></code></dt>
-<dd>Filename or description of the font displayed on the keyboard. Can be <code>null</code> or empty string.</dd>
+  <dt><code><?php echo $param7 ?></code></dt>
+  <dd>ID of the keyboard package.</dd>
+  <dt><code><?php echo $param1 ?></code></dt>
+  <dd>ID of the keyboard.</dd>
+  <dt><code><?php echo $param2 ?></code></dt>
+  <dd>ID of the associated language.</dd>
 </dl>
 
 <h3 id="Returns" name="Returns">Returns</h3>
 <p>Returns <code>true</code> if the keyboard was set successfully, <code>false</code> otherwise.</p>
 
 <h2 id="Description" name="Description">Description</h2>
-<p>This syntax can be used to set a keyboard which is either downloaded or included in the <code>assets/languages/</code> folder.</p>
+<p>Use this syntax to set a keyboard which has already been added into the keyboards list.</p>
 
 <br><hr>
 
 <h2 id="Syntax" name="Syntax">Syntax</h2>
 <pre class="language-javascript"><code><?php echo $methodSyntax3 ?></code></pre>
+
+<h3 id="Parameters" name="Parameters">Parameters</h3>
+<dl>
+  <dt><code><?php echo $param7 ?></code></dt>
+  <dd>ID of the keyboard package.</dd>
+  <dt><code><?php echo $param1 ?></code></dt>
+  <dd>ID of the keyboard.</dd>
+  <dt><code><?php echo $param2 ?></code></dt>
+  <dd>ID of the associated language.</dd>
+  <dt><code><?php echo $param3 ?></code></dt>
+  <dd>Name of the keyboard.</dd>
+  <dt><code><?php echo $param4 ?></code></dt>
+  <dd>Name of the associated language.</dd>
+  <dt><code><?php echo $param5 ?></code></dt>
+  <dd>Filename or description of the font to type with the keyboard. Can be <code>null</code> or empty string.</dd>
+  <dt><code><?php echo $param6 ?></code></dt>
+  <dd>Filename or description of the font displayed on the keyboard. Can be <code>null</code> or empty string.</dd>
+</dl>
+
+<h3 id="Returns" name="Returns">Returns</h3>
+<p>Returns <code>true</code> if the keyboard was set successfully, <code>false</code> otherwise.</p>
+
+<h2 id="Description" name="Description">Description</h2>
+<p>Use this syntax to set a keyboard which has already been added into the keyboards list.</p>
+
+<br><hr>
+
+<h2 id="Syntax" name="Syntax">Syntax</h2>
+<pre class="language-javascript"><code><?php echo $methodSyntax4 ?></code></pre>
 
 <h3 id="Parameters" name="Parameters">Parameters</h3>
 <dl>
@@ -90,19 +116,26 @@
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Example:_Using_method" name="Example:_Using_method">Example 1: Using <code><?php echo $method.'()' ?></code></h3>
-<p>The following script illustrate the use of <code><?php echo $method.'()' ?></code>:</p>
+<p>The following script illustrate the use of <code><?php echo $method.'()' ?></code> with keyboard information:</p>
 <pre class="language-javascript line-numbers"><code>    // Setting a Keyman keyboard
-    KMManager.setKeyboard("EuroLatin2", "en");
+    Keyboard keyboardInfo = KMManager.getDefaultKeyboard();
+    KMManager.setKeyboard(getApplicationContext(), keyboardInfo);
 </code></pre>
 
 <h3 id="Example:_Using_method" name="Example:_Using_method">Example 2: Using <code><?php echo $method.'()' ?></code></h3>
-<p>The following script illustrate the use of <code><?php echo $method.'()' ?></code>:</p>
-<pre class="language-javascript line-numbers"><code>    // Setting a custom keyboard which exists in assets/languages/
-    KMManager.setKeyboard("tamil99m", "ta", "Tamil 99M", "Tamil", "aava1.ttf", "aava1.ttf");
+<p>The following script illustrate the use of <code><?php echo $method.'()' ?></code> with package ID, keyboard ID, and language ID:</p>
+<pre class="language-javascript line-numbers"><code>    // Setting a Keyman keyboard
+    KMManager.setKeyboard("sil_euro_latin", "sil_euro_latin", "en");
 </code></pre>
 
 <h3 id="Example:_Using_method" name="Example:_Using_method">Example 3: Using <code><?php echo $method.'()' ?></code></h3>
 <p>The following script illustrate the use of <code><?php echo $method.'()' ?></code>:</p>
+<pre class="language-javascript line-numbers"><code>    // Setting a custom keyboard from the tamil99m keyboard package
+    KMManager.setKeyboard("tamil99m", "tamil99m", "ta", "Tamil 99M", "Tamil", "aava1.ttf", "aava1.ttf");
+</code></pre>
+
+<h3 id="Example:_Using_method" name="Example:_Using_method">Example 4: Using <code><?php echo $method.'()' ?></code></h3>
+<p>The following script illustrate the use of <code><?php echo $method.'()' ?></code> with keyboard index:</p>
 <pre class="language-javascript line-numbers"><code>    // Setting a custom keyboard which exists in keyboards list
     int kbIndex = KMManager.getKeyboardIndex(this, "tamil99m", "ta");
     KMManager.setKeyboard(this, kbIndex);

--- a/developer/engine/android/14.0/KMManager/setKeymanLicense.php
+++ b/developer/engine/android/14.0/KMManager/setKeymanLicense.php
@@ -35,6 +35,9 @@
     // Initialize KMManager here after setting the license
 </code></pre>
 
+<h2 id="History" name="History">History</h2>
+<p>Deprecated in Keyman Engine for Android 12.0</p>
+
 <h2 id="See_also" name="See_also">See also</h2>
 <ul>
 <li><a href="initialize.php"><code>KMManager.initialize()</code></a></li>

--- a/developer/engine/android/14.0/KMManager/setMaySendCrashReport.md
+++ b/developer/engine/android/14.0/KMManager/setMaySendCrashReport.md
@@ -1,0 +1,37 @@
+---
+title: KMManager.setMaySendCrashReport()
+---
+
+## Summary
+The **setMaySendCrashReport()** enables or disables whether Keyman Engine can send crash reports over the 
+network to sentry.keyman.com.
+
+## Syntax
+```java
+KMManager.setMaySendCrashReport(boolean value)
+```
+
+## Parameters
+value
+
+Set `true` to enable crash reports to be sent, `false` to disable.
+
+## Description
+Use this method to enable or disable whether Keyman Engine can send crash reports over the network. 
+By default sending crash reports is enabled.
+
+If you don't want crash reports to be sent, your app must disable this before `KMManager.initialize()`.
+
+## Examples
+
+### Example: Using setMaySendCrashReport()
+The following script illustrates the use of `setMaySendCrashReport()`: 
+```java
+    // Disable crash reports from being sent
+    KMManager.setMaySendCrashReport(false);
+    // Initialize KMManager
+    KMManager.initialize(getApplicationContext(), KeyboardType.KEYBOARD_TYPE_INAPP);
+```
+
+## See also
+* [getMaySendCrashReport](getMaySendCrashReport)

--- a/developer/engine/android/14.0/KMManager/setMaySendCrashReport.md
+++ b/developer/engine/android/14.0/KMManager/setMaySendCrashReport.md
@@ -33,5 +33,8 @@ The following script illustrates the use of `setMaySendCrashReport()`:
     KMManager.initialize(getApplicationContext(), KeyboardType.KEYBOARD_TYPE_INAPP);
 ```
 
+## History
+Added syntax in Keyman Engine for Android 14.0.
+
 ## See also
 * [getMaySendCrashReport](getMaySendCrashReport)

--- a/developer/engine/android/14.0/KMManager/showLanguageList.php
+++ b/developer/engine/android/14.0/KMManager/showLanguageList.php
@@ -39,6 +39,9 @@
     });
 </code></pre>
 
+<h2 id="History" name="History">History</h2>
+<p>Deprecated syntax in Keyman Engine for Android 14.0</p>
+
 <h2 id="See_also" name="See_also">See also</h2>
 <ul>
  <li><a href="showKeyboardPicker.php"><code>showKeyboardPicker()</code></a></li>


### PR DESCRIPTION
This starts to address #180

Add new KMManager API's
* getDefaultKeyboard()
* setDefaultKeyboard()
* getMaySendCrashReport() (See keymanapp/keyman#3825)
* setMaySendCrashReport()

Modifications
* Update the add/get/set Keyboard methods to use the new Keyboard type. (Mark HashMap dictionaries as *(Deprecated)*)
