### PR TITLE
Move howto pages

### DIFF
--- a/knowledge-base/kb0101.md
+++ b/knowledge-base/kb0101.md
@@ -1,0 +1,36 @@
+# Using Keyman for Linux with KDE
+
+Unfortunately when using the KDE desktop environment the support for ibus (which Keyman for Linux uses underneath) isn’t that great. If you want to use Keyman with KDE you’ll have to do some manual steps:
+
+1. Install additional packages: in a terminal window, run:
+
+    ```bash
+    sudo apt update
+    sudo apt install ibus-qt4 ibus-gtk
+    ```
+
+2. Add
+
+    ```bash
+    export GTK_IM_MODULE=ibus
+    export XMODIFIERS=@im=ibus
+    export QT_IM_MODULE=ibus
+    ```
+
+    to your `$HOME/.xsessionrc`.
+
+3. Auto-start the ibus daemon on every login. Run the following command in a terminal window:
+
+    ```bash
+    echo "ibus-daemon -d -x -r -n kde" > $HOME/.config/autostart-scripts/ibus-daemon-autostart.sh
+    chmod +x $HOME/.config/autostart-scripts/ibus-daemon-autostart.sh
+    ```
+
+4. Reboot so that the changes you made get applied to the new session.
+
+Now you should be able to install Keyman for Linux and add and use Keyman keyboards.
+
+**NOTE:** it seems that some KDE specific programs like Konsole aren’t designed to work with
+ibus/Keyman keyboards. To test if a Keyman keyboard works you can e.g. test with LibreOffice Writer.
+
+(cf. <https://wiki.debian.org/I18n/ibus>)

--- a/knowledge-base/kb0101.md
+++ b/knowledge-base/kb0101.md
@@ -1,6 +1,8 @@
-# Using Keyman for Linux with KDE
+# HOWTO: Using Keyman for Linux with KDE
 
-Unfortunately when using the KDE desktop environment the support for ibus (which Keyman for Linux uses underneath) isn’t that great. If you want to use Keyman with KDE you’ll have to do some manual steps:
+Unfortunately when using the KDE desktop environment, the support for ibus (which Keyman for Linux
+uses underneath) isn’t that great. If you want to use Keyman with KDE you’ll have to do some manual
+steps:
 
 1. Install additional packages: in a terminal window, run:
 

--- a/knowledge-base/kb0101.md
+++ b/knowledge-base/kb0101.md
@@ -30,7 +30,12 @@ Unfortunately when using the KDE desktop environment the support for ibus (which
 
 Now you should be able to install Keyman for Linux and add and use Keyman keyboards.
 
+---
 **NOTE:** it seems that some KDE specific programs like Konsole aren’t designed to work with
 ibus/Keyman keyboards. To test if a Keyman keyboard works you can e.g. test with LibreOffice Writer.
 
-(cf. <https://wiki.debian.org/I18n/ibus>)
+---
+
+## References
+
+- <https://wiki.debian.org/I18n/ibus>

--- a/knowledge-base/kb0102.md
+++ b/knowledge-base/kb0102.md
@@ -1,0 +1,72 @@
+# How to install IBus and Keyman on Arch Linux and derivatives
+
+## IBus
+
+Problem with dependencies, such as:
+
+> "installing pygobject-devel (3.32.1-1) breaks dependency 'pygobject-devel=3.30.4' required by python-gobject".
+
+could be solved by upgrading the system:
+
+```bash
+sudo pacman -Syyu
+```
+
+**Notice:** any OS based on Arch Linux needs a regular full upgrade because of rolling release
+concept.
+
+Install IBus:
+
+```bash
+sudo pacman -S ibus kimtoy
+```
+
+Run KIMToy from the Application Launcher (use search field). It will add a new icon into the tray,
+from its menu activate "Autostart", and in "Configure KIMToy" go to the IBus tab:
+
+* activate "Run IBus at startup"
+* field "Arguments" set to "-drx"
+
+Log-out from the desktop session and log-in again (or restart computer).
+
+Now IBus on itself should work, you could add another layout (e.g. Arabic) and test it in Libre
+Office. If it does not work, read [Arch Linux Wiki][1].
+
+## Keyman
+
+Keyman is in the Arch User Repository (AUR). (KOSMOS does not provide tools to install applications from AUR, so you need another package manager, for example `pamac`):
+
+```bash
+sudo pacman -S vte3 itstool vala gobject-introspection
+
+cd ~
+wget https://aur.archlinux.org/cgit/aur.git/snapshot/pamac-aur.tar.gz
+tar xvzf pamac-aur.tar.gz
+cd pamac-aur
+makepkg
+makepkg -i
+```
+
+Run `pamac` from the Application Launcher (it is called "Add/Remove Software") or from console
+(`pamac-manager`). Go to the Preference menu (button with 3 vertical dots in the upper right corner)
+and activate "Enable AUR support". Return to the main window and search for "keyman", there should
+be two applications, install them:
+
+* keyman 11.0.122-1
+* keyman-onboard 1.4.1
+
+(Packages `kmflcomp`, `libkmfl`, `ibus-kmfl` belong to an old version of Keyman, ignore them.)
+
+Several dependencies of Keyman are not included into KOSMOS system, install them also from `pamac`:
+
+* python-numpy (Repositories)
+* python-magic (AUR)
+* python-requests-cache (AUR)
+
+Now all Keyman's utilities should work. Search Application Launcher for "Keyman Keyboards"
+(km-config) for installing required keyboards. Layout will be automaticly added into IBus, if not —
+restart IBus (right click on the icon in the tray).
+
+[1]: https://wiki.archlinux.org/index.php/IBus#Initial_setup
+
+(original version in <https://github.com/keymanapp/keyman/issues/1762>)

--- a/knowledge-base/kb0102.md
+++ b/knowledge-base/kb0102.md
@@ -1,4 +1,4 @@
-# How to install IBus and Keyman on Arch Linux and derivatives
+# HOWTO: Installation of IBus and Keyman on Arch Linux and derivatives
 
 ## IBus
 
@@ -64,7 +64,7 @@ Several dependencies of Keyman are not included into KOSMOS system, install them
 * python-requests-cache (AUR)
 
 Now all Keyman's utilities should work. Search Application Launcher for "Keyman Keyboards"
-(km-config) for installing required keyboards. Layout will be automaticly added into IBus, if not —
+(km-config) for installing required keyboards. Layout will be automatically added into IBus, if not —
 restart IBus (right click on the icon in the tray).
 
 [1]: https://wiki.archlinux.org/index.php/IBus#Initial_setup

--- a/knowledge-base/kb0103.md
+++ b/knowledge-base/kb0103.md
@@ -26,8 +26,8 @@ Next paste these commands:
 wget -qO - http://linux.lsdev.sil.org/downloads/sil-testing.gpg | sudo apt-key add -
 sudo add-apt-repository "deb http://linux.lsdev.sil.org/ubuntu $(lsb_release -sc)-experimental main"
 sudo apt-get update
-sudo apt-get install keyman
+sudo apt-get install keyman onboard
 ```
 
 This will install the LLSO key, add the LLSO package repositories, refresh the package list, and
-install Keyman for Linux.
+install Keyman for Linux as well as the _onboard_ on-screen keyboard.

--- a/knowledge-base/kb0103.md
+++ b/knowledge-base/kb0103.md
@@ -1,0 +1,32 @@
+# How to install nightly packages of Keyman for Linux
+
+Nightly alpha packages of Keyman for Linux are available on llso.
+
+## Warning
+
+**WARNING:** "nightly" experimental packages are untested, unsupported, and may cause problems on
+your system. Do not install nightly (experimental) packages unless you understand what you are
+getting into.
+
+## Install
+
+Launch **Terminal** and paste in the following commands. You can paste in Terminal by pressing
+`CTRL-SHIFT-V`.
+
+First paste this command to get sudo going. It may ask for your password.
+
+```bash
+sudo echo have sudo
+```
+
+Next paste these commands:
+
+```bash
+wget -qO - http://linux.lsdev.sil.org/downloads/sil-testing.gpg | sudo apt-key add -
+sudo add-apt-repository "deb http://linux.lsdev.sil.org/ubuntu $(lsb_release -sc)-experimental main"
+sudo apt-get update
+sudo apt-get install keyman
+```
+
+This will install the LLSO key, add the LLSO package repositories, refresh the package list, and
+install Keyman for Linux.

--- a/knowledge-base/kb0103.md
+++ b/knowledge-base/kb0103.md
@@ -1,6 +1,7 @@
-# How to install nightly packages of Keyman for Linux
+# HOWTO: Installation of nightly packages of Keyman for Linux
 
-Nightly alpha packages of Keyman for Linux are available on llso.
+Nightly alpha packages of Keyman for Linux are available on LLSO (package repo on
+linux.lsdev.sil.org).
 
 ## Warning
 


### PR DESCRIPTION
- "Using Keyman for Linux with KDE" from community site
- "How to install IBus and Keyman on Arch Linux and derivatives" and "How to install nightly packages of Keyman for Linux" from Keyman wiki

Once this PR is merged we should replace the content of the original pages with links to the KB articles