### PR TITLE
chore: Use consistent headers between API versions

### DIFF
--- a/_includes/includes/history_utils.php
+++ b/_includes/includes/history_utils.php
@@ -42,30 +42,33 @@ function display_history($platform, $version = '1.0'){
     $contents = $platform_title[$platform] . $contents;
 
     // Adjust the publish dates of API 2.0 for displaying on website
-    $regex_dated_version_src = "/(\d+.\d+(.\d+)? (?:stable|beta|alpha)) (\d{4}-\d{2}-\d{2})/"; // (\d+.\d+.\d+) [stable|beta|alpha]
+    $regex_dated_version_src = "/(\d+.\d+(.\d+)? (?:stable|beta|alpha)) (\d{4}-\d{2}-\d{2})/";
     $regex_dated_version_dst = "\${1}\n Published \${3}.";
 
     // The actual replacements.
     //$contents = preg_replace($regex_header_line, "", $contents);
     $contents = preg_replace($regex_dated_version_src, $regex_dated_version_dst, $contents);
 
-    // Tighten formatting -- h3, remove redundant paragraphs
-    $contents = preg_replace('/^## /m', '### ', $contents);
-    $contents = preg_replace("/\n\n\\* /", "\n* ", $contents);
-    // Include previous Keyman history
-    $contents = $contents . '<br><br>' . get_history($platform, '1.0');
+    // Include previous Keyman history (minus its title)
+    $previous_contents = get_history($platform, '1.0');
+    $previous_contents = preg_replace('/^#.*/', '<br>', $previous_contents);
+    $contents = $contents . $previous_contents;
   }
 
   // Adjust the publish dates of API 1.0 for displaying on website
   // Only needed if using header.php, not if using template.php.
   //$regex_header_line = "/^# [^\n]+/";
 
-  $regex_dated_version_src = "/(\d{4}-\d{2}-\d{2}) (\d+.\d+(.\d+)? (?:stable|beta|alpha))/"; // (\d+.\d+.\d+) [stable|beta|alpha]
+  $regex_dated_version_src = "/(\d{4}-\d{2}-\d{2}) (\d+.\d+(.\d+)? (?:stable|beta|alpha))/";
   $regex_dated_version_dst = "\${2}\n Published \${1}.";
 
   // The actual replacements.
   //$contents = preg_replace($regex_header_line, "", $contents);
   $contents = preg_replace($regex_dated_version_src, $regex_dated_version_dst, $contents);
+
+  // Tighten formatting -- h3, remove redundant paragraphs
+  $contents = preg_replace('/^## /m', '### ', $contents);
+  $contents = preg_replace("/\n\n\\* /", "\n* ", $contents);
 
   // Performs the parsing + prettification of Markdown for display through PHP.
   $Parsedown = new \ParsedownExtra();


### PR DESCRIPTION
Follow-on to #262 

The regex to tighten formatting needs to be applied to the entire history display. (Currently, help.keyman-staging is using `<h3>` for 14.0 history and `<h2>` for older history.

This also strips out the title when merging in older history.

Screenshot of developer/engine/web/historyhistory
![consistent version](https://user-images.githubusercontent.com/7358010/100822016-16eeac80-3484-11eb-8cf6-263aea78e4a4.PNG)
