### PR TITLE
feat(linux): Rename onboard package

### DIFF
--- a/knowledge-base/kb0103.md
+++ b/knowledge-base/kb0103.md
@@ -26,8 +26,8 @@ Next paste these commands:
 wget -qO - http://linux.lsdev.sil.org/downloads/sil-testing.gpg | sudo apt-key add -
 sudo add-apt-repository "deb http://linux.lsdev.sil.org/ubuntu $(lsb_release -sc)-experimental main"
 sudo apt-get update
-sudo apt-get install keyman onboard
+sudo apt-get install keyman onboard-keyman
 ```
 
 This will install the LLSO key, add the LLSO package repositories, refresh the package list, and
-install Keyman for Linux as well as the _onboard_ on-screen keyboard.
+install Keyman for Linux as well as the _onboard-keyman_ on-screen keyboard.

--- a/products/linux/14.0/common.php
+++ b/products/linux/14.0/common.php
@@ -18,7 +18,7 @@ head([
   <pre><code class="language-bash">sudo add-apt-repository ppa:keymanapp/keyman
 sudo apt-get update
 sudo apt-get upgrade
-sudo apt-get install keyman ibus-keyman onboard</code></pre>
+sudo apt-get install keyman onboard-keyman</code></pre>
 </p>
 <p>
   Keyman for Linux packages are also available in any current Debian at:


### PR DESCRIPTION
Update the documentation for the renamed onboard package. The package name is now `onboard-keyman` instead of `onboard`.
Part of keymanapp/keyman#3966.