### PR TITLE
chore: github action php 7.4 dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       with:
         php-version: '7.4'
         extensions: curl, intl, mbstring, openssl
+        coverage: none
+        env: fail-fast
 
     #
     # Configure IIS and setup site for running unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,14 @@ jobs:
       KEYMANHOSTS_TIER: TIER_TEST
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup PHP 7.4
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.4'
+      extensions: curl, intl, mbstring, openssl
 
     #
     # Configure IIS and setup site for running unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '7.4'
-      extensions: curl, intl, mbstring, openssl
+        extensions: curl, intl, mbstring, openssl
 
     #
     # Configure IIS and setup site for running unit tests


### PR DESCRIPTION
The GitHub action runner [has been updated to 8.0.1](https://github.com/actions/virtual-environments/blob/releases/win19/20210110/images/win/Windows2019-Readme.md) but many of our dependencies do not currently support it without updates. For now, we will test on our supported version of PHP using the [setup-php action](https://github.com/marketplace/actions/setup-php-action), as recommended by https://github.com/actions/virtual-environments/issues/2416.