### PR TITLE
fix: markdown header parser was not parsing some headers

### DIFF
--- a/_common/MarkdownHost.php
+++ b/_common/MarkdownHost.php
@@ -55,7 +55,7 @@
           $found = false;
           break;
         } else {
-          $headers[$match[1]] = $match[2];
+          $headers[$match[1]] = trim($match[2]);
         }
       }
       $found = $found && $i < count($lines);


### PR DESCRIPTION
This replaces the somewhat fragile regex with a simple line-based parser of the headers. Seems to be somewhat cleaner.