### PR TITLE
feat: add  isKeyboardLoaded

### DIFF
--- a/developer/engine/android/14.0/KMManager/getDefaultKeyboard.md
+++ b/developer/engine/android/14.0/KMManager/getDefaultKeyboard.md
@@ -10,7 +10,7 @@ The `getDefaultKeyboard()` method returns the keyboard information for the fallb
 KMManager.getDefaultKeyboard()
 ```
 
-## Returns
+### Returns
 Returns `Keyboard` type for the fallback keyboard. If not specified, this defaults to keyboard information for sil_euro_latin.
 
 ## Description

--- a/developer/engine/android/14.0/KMManager/getMaySendCrashReport.md
+++ b/developer/engine/android/14.0/KMManager/getMaySendCrashReport.md
@@ -10,7 +10,7 @@ The **getMaySendCrashReport()** method returns whether Keyman Engine is allowed 
 KMManager.getMaySendCrashReport()
 ```
 
-## Returns
+### Returns
 Returns `true` if crash reports can be sent over the network to sentry.keyman.com, `false` otherwise.
 
 ## Description

--- a/developer/engine/android/14.0/KMManager/index.php
+++ b/developer/engine/android/14.0/KMManager/index.php
@@ -148,6 +148,9 @@
   <dt><code><a href='isHelpBubbleEnabled.php'>isHelpBubbleEnabled()</a></code></dt>
   <dd>returns whether the help bubble is enabled</dd>
 
+  <dt><code><a href='isKeyboardLoaded'>isKeyboardLoaded()</a></code></dt>
+  <dd>returns whether the specified in-app or system keyboard is loaded</dd>
+
   <dt><code><a href='keyboardExists.php'>keyboardExists()</a></code></dt>
   <dd>returns whether the specified keyboard exists in keyboards list</dd>
 

--- a/developer/engine/android/14.0/KMManager/isKeyboardLoaded.md
+++ b/developer/engine/android/14.0/KMManager/isKeyboardLoaded.md
@@ -1,0 +1,44 @@
+---
+title: KMManager.isKeyboardLoaded()
+---
+
+## Summary
+The **isKeyboardLoaded()** method returns whether the specified in-app or system keyboard is loaded.
+
+## Syntax
+```java
+KMManager.isKeyboardLoaded(KeyboardType type)
+```
+
+### Parameters
+type
+
+: `KeyboardType.KEYBOARD_TYPE_INAPP` or `KeyboardType.KEYBOARD_TYPE_SYSTEM`
+
+If type is `KeyboardType.KEYBOARD_TYPE_UNDEFINED`, the function will return `false`.
+
+### Returns
+Returns `true` if the specified keyboard is loaded, `false` otherwise.
+
+## Description
+Use this method to check if a keyboard is loaded and ready to use.
+
+---
+
+## Examples
+
+### Example: Using isKeyboardLoaded
+The following script illustrate the use of `isKeyboardLoaded`
+
+```java
+if (KMManager.isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) {
+   // Get the keyboard info at index 0
+   Keyboard keyboardInfo = KMManager.getKeyboardInfo(this, 0)
+}
+```
+
+## History
+Added syntax in Keyman Engine for Android 14.0.
+
+## See also
+* [setKeyboard](setKeyboard)

--- a/developer/engine/android/14.0/KMManager/setMaySendCrashReport.md
+++ b/developer/engine/android/14.0/KMManager/setMaySendCrashReport.md
@@ -11,7 +11,7 @@ network to sentry.keyman.com.
 KMManager.setMaySendCrashReport(boolean value)
 ```
 
-## Parameters
+### Parameters
 value
 
 Set `true` to enable crash reports to be sent, `false` to disable.


### PR DESCRIPTION
Documents KMManager.isKeyboardLoaded() from keymanapp/keyman#4696

Also fixes some `###Parameters` and `### Returns` headers to nest under `## Syntax`