### PR TITLE
chore: Remove TODO files

### DIFF
--- a/products/windows/14.0/TODO.md
+++ b/products/windows/14.0/TODO.md
@@ -1,7 +1,0 @@
-- search for TODO
-- search for title: ... {...}
-- search for "(desktop_images"
-- search for "](#"
-- search for \n\n- (gaps between bullets)
-- search for ^**...**$
-- search for keyboard references and use <kbd></kbd>

--- a/products/windows/15.0/TODO.md
+++ b/products/windows/15.0/TODO.md
@@ -1,7 +1,0 @@
-- search for TODO
-- search for title: ... {...}
-- search for "(desktop_images"
-- search for "](#"
-- search for \n\n- (gaps between bullets)
-- search for ^**...**$
-- search for keyboard references and use <kbd></kbd>


### PR DESCRIPTION
Fixes #375 by removing obsolete TODO.md files.

They were already removed in the main repo by keymanapp/keyman#4717 so hopefully they won't reappear when the help docs sync.