### PR TITLE
fix: we should not use backtick in live code yet

### DIFF
--- a/cdn/dev/js/kbd-docs.js
+++ b/cdn/dev/js/kbd-docs.js
@@ -110,17 +110,17 @@ function loaded(){
             if(!fontSource) continue;
             var fontType = fontSource.match(/\.woff$/i) ? 'woff' : 'truetype';
             // Add the font information
-            $('head').append($(`
-<style>
-@font-face {
-	font-family:"${fontFamily}";
-	font-style:normal;
-	font-weight:normal;
-	src:url('https://s.keyman.com/font/deploy/${fontSource}') format('${fontType}');
-}
-.kmw-key-text { font-family: "${fontFamily}"; }
-</style>
-`));
+            $('head').append($(
+"<style>\n"+
+"@font-face {\n"+
+"	font-family:\""+fontFamily+"\";\n"+
+"	font-style:normal;\n"+
+"	font-weight:normal;\n"+
+"	src:url('https://s.keyman.com/font/deploy/${fontSource}') format('${fontType}');\n"+
+"}\n"+
+".kmw-key-text { font-family: \""+fontFamily+"\"; }\n"+
+"</style>"
+));
             return;
           }
         }

--- a/cdn/dev/js/kbd-docs.js
+++ b/cdn/dev/js/kbd-docs.js
@@ -116,7 +116,7 @@ function loaded(){
 "	font-family:\""+fontFamily+"\";\n"+
 "	font-style:normal;\n"+
 "	font-weight:normal;\n"+
-"	src:url('https://s.keyman.com/font/deploy/${fontSource}') format('${fontType}');\n"+
+"	src:url('https://s.keyman.com/font/deploy/"+fontSource+"') format('"+fontType+"');\n"+
 "}\n"+
 ".kmw-key-text { font-family: \""+fontFamily+"\"; }\n"+
 "</style>"


### PR DESCRIPTION
This is a problem for some browsers, e.g. Opera Mini. We don't use backtick widely so let's just remove it for now.

Fixes [HELP-KEYMAN-COM-10](https://sentry.keyman.com/organizations/keyman/issues/4254/), [HELP-KEYMAN-COM-15](https://sentry.keyman.com/organizations/keyman/issues/4283/).