### PR TITLE
chore: Add note about word-breaking in lexical-model guide

### DIFF
--- a/developer/14.0/guides/lexical-models/tutorial/step-1.php
+++ b/developer/14.0/guides/lexical-models/tutorial/step-1.php
@@ -12,8 +12,18 @@
 
 <ul>
   <li>Install <a href="https://keyman.com/developer">Keyman Developer</a> 12.0 or greater (Windows only)</li>
-  <li> A list of words in your langauge, stored in an spreadsheet, in dictionary-making software or, other means. </li>
+  <li>A list of words in your language, stored in an spreadsheet, in dictionary-making software or, other means. </li>
 </ul>
+
+<aside>
+  <h3>Note</h3>
+  <p>Currently, lexical models work better with languages that use regular spaces as word boundaries. For complex
+    scripts such as Khmer, Thai, Lao, etc, a pre-processing is required before getting it to work, i.e. word segmentation
+    has to be determined and/or configured. See the advanced topic on making a custom
+    <a href='../advanced/word-breaker'>word breaker</a>.</p>
+
+  <p>This will be addressed in a future <a href='https://github.com/keymanapp/keyman/issues/5025'>feature</a>.</p>
+</aside>
 
 <p> Now to create a lexical model project!</p>
 


### PR DESCRIPTION
Fixes #392 adding a note about word breaking in the lexical-model prerequisites.