### PR TITLE
fix: Broken image links in knowledge base article

### DIFF
--- a/knowledge-base/kb0040.md
+++ b/knowledge-base/kb0040.md
@@ -8,11 +8,11 @@ Keyman Support may ask you to send a support diagnostic. These reports assist us
 <a href='https://downloads.keyman.com/tools/tsysinfo/tsysinfo.exe'>tsysinfo.exe</a> (5MB)</p></div>
 
 * **Open Keyman Configuration.**
-  * Click on the <span class="guiicon">Keyman Desktop</span> icon <span class="inlinemediaobject"><img src="/products/desktop/current-version/docs/desktop_images/icon-keyman.png"></span>, on the Windows Taskbar near the clock.
-  * From the Keyman Desktop menu, select <span class="guilabel">Configuration…</span>.
+  * Click on the <span class="guiicon">Keyman for Windows (previously Keyman Desktop)</span> icon <span class="inlinemediaobject"><img src="/products/windows/current-version/desktop_images/icon-keyman.png"></span>, on the Windows Taskbar near the clock.
+  * From the Keyman menu, select <span class="guilabel">Configuration…</span>.
 
 * **Select the Support tab.**
-  <img src="/products/desktop/current-version/docs/desktop_images/tab-support.png" width="700" height="493" alt='Click Support'>
+  <img src="/products/windows/current-version/desktop_images/tab-support.png" width="700" height="493" alt='Click Support'>
 
 * **Click 'Diagnostics' link**
   * You can collect diagnostic information about Keyman by clicking the 'Diagnostics' link under the 'Useful Links' section. The support diagnostic will collect critical diagnostic information from your computer and generate a report.
@@ -45,3 +45,4 @@ Keyman Support may ask you to send a support diagnostic. These reports assist us
  * Keyman Desktop 11.0
  * Keyman Desktop 12.0
  * Keyman Desktop 13.0
+ * Keyman 14.0 for Windows


### PR DESCRIPTION
Fixes #409 

The path for Keyman for WIndows help images recently changed  - breaking the image links in the knowledge base article.