### PR TITLE
auto: Keyman for mac help deployment

### DIFF
--- a/products/mac/15.0/about/whatsnew.md
+++ b/products/mac/15.0/about/whatsnew.md
@@ -9,3 +9,6 @@ Here are some of the new features we have added to Keyman 14.0 for macOS:
 * Added support for European layouts in On Screen Keyboard (#3924)
 * Made it possible to specify app compatibility modes as a user default (#3949)
 * Improved input reliability with modifier keys and cursor keys (#2588, #3946)
+
+[![](../mac_images/video.png) Watch a video](https://youtu.be/YBE7s07bmBM)
+that highlights some of these new features.


### PR DESCRIPTION
For some reason this didn't get auto-merged

Update: @mcdurdin noted cause the build agent didn't have hub installed.

This content is also duplicated in auto/mac-help-15.0.69-alpha so we just need one of them.