### PR TITLE
chore: Remove usage of loader script

### DIFF
--- a/developer/engine/web/10.0/guide/adding-keyboards.php
+++ b/developer/engine/web/10.0/guide/adding-keyboards.php
@@ -45,15 +45,6 @@ font:{
 }
 </code></pre>
 
-<h2>Using a loader script</h2>
-
-<p>When Keyman Developer compiles a keyboard, it produces not only a <code>*.js</code> file for the keyboard itself but
-also a keyboard stub loader, which generally uses the same filename suffixed with <code>_load</code>.  The following HTML
-tag would work for the above example, but only if both <code>*.js</code> files are placed in the same directory as the code
-page utilizing them due to limitations imposed by the page-loading process.</p>
-
-<pre><code>&lt;script src='./us-1.0_load.js'&gt;&lt;/script&gt;</code></pre>
-
 <h2>Requested from the CDN by language name</h2>
 
 <p>To obtain the default Keyman keyboard for a given language, call the following function.</p>

--- a/developer/engine/web/11.0/guide/adding-keyboards.php
+++ b/developer/engine/web/11.0/guide/adding-keyboards.php
@@ -45,15 +45,6 @@ font:{
 }
 </code></pre>
 
-<h2>Using a loader script</h2>
-
-<p>When Keyman Developer compiles a keyboard, it produces not only a <code>*.js</code> file for the keyboard itself but
-also a keyboard stub loader, which generally uses the same filename suffixed with <code>_load</code>.  The following HTML
-tag would work for the above example, but only if both <code>*.js</code> files are placed in the same directory as the code
-page utilizing them due to limitations imposed by the page-loading process.</p>
-
-<pre><code>&lt;script src='./us-1.0_load.js'&gt;&lt;/script&gt;</code></pre>
-
 <h2>Requested from the CDN by language name</h2>
 
 <p>To obtain the default Keyman keyboard for a given language, call the following function.</p>

--- a/developer/engine/web/12.0/guide/adding-keyboards.php
+++ b/developer/engine/web/12.0/guide/adding-keyboards.php
@@ -45,15 +45,6 @@ font:{
 }
 </code></pre>
 
-<h2>Using a loader script</h2>
-
-<p>When Keyman Developer compiles a keyboard, it produces not only a <code>*.js</code> file for the keyboard itself but
-also a keyboard stub loader, which generally uses the same filename suffixed with <code>_load</code>.  The following HTML
-tag would work for the above example, but only if both <code>*.js</code> files are placed in the same directory as the code
-page utilizing them due to limitations imposed by the page-loading process.</p>
-
-<pre><code>&lt;script src='./us-1.0_load.js'&gt;&lt;/script&gt;</code></pre>
-
 <h2>Requested from the CDN by language name</h2>
 
 <p>To obtain the default Keyman keyboard for a given language, call the following function.</p>

--- a/developer/engine/web/13.0/guide/adding-keyboards.php
+++ b/developer/engine/web/13.0/guide/adding-keyboards.php
@@ -45,15 +45,6 @@ font:{
 }
 </code></pre>
 
-<h2>Using a loader script</h2>
-
-<p>When Keyman Developer compiles a keyboard, it produces not only a <code>*.js</code> file for the keyboard itself but
-also a keyboard stub loader, which generally uses the same filename suffixed with <code>_load</code>.  The following HTML
-tag would work for the above example, but only if both <code>*.js</code> files are placed in the same directory as the code
-page utilizing them due to limitations imposed by the page-loading process.</p>
-
-<pre><code>&lt;script src='./us-1.0_load.js'&gt;&lt;/script&gt;</code></pre>
-
 <h2>Requested from the CDN by language name</h2>
 
 <p>To obtain the default Keyman keyboard for a given language, call the following function.</p>

--- a/developer/engine/web/14.0/guide/adding-keyboards.php
+++ b/developer/engine/web/14.0/guide/adding-keyboards.php
@@ -45,15 +45,6 @@ font:{
 }
 </code></pre>
 
-<h2>Using a loader script</h2>
-
-<p>When Keyman Developer compiles a keyboard, it produces not only a <code>*.js</code> file for the keyboard itself but
-also a keyboard stub loader, which generally uses the same filename suffixed with <code>_load</code>.  The following HTML
-tag would work for the above example, but only if both <code>*.js</code> files are placed in the same directory as the code
-page utilizing them due to limitations imposed by the page-loading process.</p>
-
-<pre><code>&lt;script src='./us-1.0_load.js'&gt;&lt;/script&gt;</code></pre>
-
 <h2>Requested from the CDN by language name</h2>
 
 <p>To obtain the default Keyman keyboard for a given language, call the following function.</p>

--- a/developer/engine/web/15.0/guide/adding-keyboards.php
+++ b/developer/engine/web/15.0/guide/adding-keyboards.php
@@ -45,15 +45,6 @@ font:{
 }
 </code></pre>
 
-<h2>Using a loader script</h2>
-
-<p>When Keyman Developer compiles a keyboard, it produces not only a <code>*.js</code> file for the keyboard itself but
-also a keyboard stub loader, which generally uses the same filename suffixed with <code>_load</code>.  The following HTML
-tag would work for the above example, but only if both <code>*.js</code> files are placed in the same directory as the code
-page utilizing them due to limitations imposed by the page-loading process.</p>
-
-<pre><code>&lt;script src='./us-1.0_load.js'&gt;&lt;/script&gt;</code></pre>
-
 <h2>Requested from the CDN by language name</h2>
 
 <p>To obtain the default Keyman keyboard for a given language, call the following function.</p>


### PR DESCRIPTION
In keymanapp/keyman#528, Keyman Developer 10.0 no longer generates loader scripts for KeymanWeb keyboards.
> They use an old mode of loading a keyboard stub, rather than the current `addKeyboards` API

This cleans up the adding-keyboards guide for engine/web/10.0 onward.