### PR TITLE
fix: link checker was skipping all links

### DIFF
--- a/_includes/includes/head.php
+++ b/_includes/includes/head.php
@@ -34,7 +34,7 @@
 <head>
   <meta charset="utf-8">
   <?php
-    if(KeymanHosts::Instance()->Tier() != KeymanHosts::TIER_PRODUCTION) {
+    if(KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_STAGING) {
       echo '    <meta name="robots" content="none">';
     }
   ?>


### PR DESCRIPTION
A fix I made in #299 to stop search engines indexing the staging sites accidentally broke the link checker, by telling it to skip all links.