### PR TITLE
feat: Document KeymanWeb API calls returning a promise

### DIFF
--- a/developer/engine/web/15.0/reference/core/addKeyboards.md
+++ b/developer/engine/web/15.0/reference/core/addKeyboards.md
@@ -4,19 +4,19 @@ title: addKeyboards function
 
 ## Summary
 
-Adds keyboards to keymanweb.
+Adds keyboards to KeymanWeb.
 
 ## Syntax
 
 ```js
-keyman.addKeyboards(spec[, spec...])
+keyman.addKeyboards([spec, spec...])
 ```
 
 ### Parameters
 
 `spec`
 
-: Type: `string|Object`
+: Type: Array of `string|Object`
 
   keyboard name string or keyboard metadata JSON object
 

--- a/developer/engine/web/15.0/reference/core/addKeyboards.md
+++ b/developer/engine/web/15.0/reference/core/addKeyboards.md
@@ -22,7 +22,12 @@ keyman.addKeyboards(spec[, spec...])
 
 ### Return Value
 
-`undefined`
+`Promise`: A [JavaScript Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+fulfilled upon adding keyboards.
+
+The promise is an array containing a combination of the following:
+* successfully registered keyboard objects which define some or all of these [properties](../keyboard_properties)
+* [ErrorStub](../keyboard_registration_errors) objects for keyboards that failed to register
 
 ## Description
 

--- a/developer/engine/web/15.0/reference/core/addKeyboards.md
+++ b/developer/engine/web/15.0/reference/core/addKeyboards.md
@@ -9,14 +9,14 @@ Adds keyboards to KeymanWeb.
 ## Syntax
 
 ```js
-keyman.addKeyboards([spec, spec...])
+keyman.addKeyboards(spec[, spec...])
 ```
 
 ### Parameters
 
 `spec`
 
-: Type: Array of `string|Object`
+: Type: `string|Object`
 
   keyboard name string or keyboard metadata JSON object
 

--- a/developer/engine/web/15.0/reference/core/addKeyboardsForLanguage.md
+++ b/developer/engine/web/15.0/reference/core/addKeyboardsForLanguage.md
@@ -9,14 +9,14 @@ Add default or all keyboards for a given language to KeymanWeb.
 ## Syntax
 
 ```js
-keyman.addKeyboardsForLanguage([spec, spec...])
+keyman.addKeyboardsForLanguage(spec[, spec...])
 ```
 
 ### Parameters
 
 `spec`
 
-: Type: Array of `string`
+: Type: `string`
 
   Language name string. Appending `$` to the language name will cause all available keyboards for that language to be loaded rather than the default keyboard.
 

--- a/developer/engine/web/15.0/reference/core/addKeyboardsForLanguage.md
+++ b/developer/engine/web/15.0/reference/core/addKeyboardsForLanguage.md
@@ -1,0 +1,45 @@
+---
+title: addKeyboardsForLanguage function
+---
+
+## Summary
+
+Add default or all keyboards for a given language to KeymanWeb.
+
+## Syntax
+
+```js
+keyman.addKeyboardsForLanguage([spec, spec...])
+```
+
+### Parameters
+
+`spec`
+
+: Type: Array of `string`
+
+  Language name string. Appending `$` to the language name will cause all available keyboards for that language to be loaded rather than the default keyboard.
+
+### Return Value
+
+`Promise`: A [JavaScript Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+fulfilled upon adding keyboards.
+
+The promise is an array containing the following:
+* successfully registered keyboard objects which define some or all of these [properties](../keyboard_properties)
+
+## Description
+
+The language spec is a string. Multiple language specs can also be
+specified in a single call, which can reduce the round-trip cost of multiple
+calls to Keyman Cloud servers (when using Keyman Cloud).
+
+The first call to `addKeyboardsForLanguage()` makes an additional call to the Keyman API to load the current list of keyboard/language associations. This determines the default keyboards that are added for the language.
+
+For general information and example uses of this method, please see the [Adding
+Keyboards](../../guide/adding-keyboards.php) page from the guide section.
+
+### Using a `string`
+
+For the given language specs, the Keyman Cloud is used to source the keyboard
+file.

--- a/developer/engine/web/15.0/reference/core/index.php
+++ b/developer/engine/web/15.0/reference/core/index.php
@@ -48,6 +48,11 @@
   </dl>
 
   <dl>
+  <dt><a href='addKeyboardsForLanguage'><code>addKeyboardsForLanguage</code> Function</a></dt>
+  <dd>Adds default or all keyboards for a given language to keymanweb.</dd>
+  </dl>
+
+  <dl>
   <dt><a href='alignInputs'><code>alignInputs</code> Function</a></dt>
   <dd>Adjusts touch-mode element overlays, realigning them over their base elements.</dd>
   </dl>

--- a/developer/engine/web/15.0/reference/core/init.md
+++ b/developer/engine/web/15.0/reference/core/init.md
@@ -93,10 +93,11 @@ The `initOptions` object may contain the following members:
 
 : `boolean` <span class="optional">optional</span>
 
-  Specifies whether KeymanWeb will display internal alerts. Default value `true`.
+  Specifies whether KeymanWeb's alert feedback should be enabled. Default value `true`.
 
-  * If `true`, KeymanWeb will display internal alerts.
-  * If `false`, KeymanWeb will not display internal alerts. Choose this if you want to customize the alert messages for use on your site.
+  * If `true`, KeymanWeb will display its default alerts.
+  * If `false`, KeymanWeb will not display its default alerts. Choose this if you wish to disable them or would prefer to customize your site's error feedback.
+  * In either case, any calls your page makes to `keyman.util.alert()` will not be blocked.  This only affects calls built into KeymanWeb itself.
 
 `spacebarText`
 
@@ -129,4 +130,3 @@ follows:
 
 : `boolean` <span class="optional">optional</span>
 : A Float-UI-only option. Sets right-alignment of the UI. Defaults to false.
-

--- a/developer/engine/web/15.0/reference/core/init.md
+++ b/developer/engine/web/15.0/reference/core/init.md
@@ -80,6 +80,24 @@ The `initOptions` object may contain the following members:
   * If `'manual'`, KeymanWeb must be instructed to attached manually to each
     control it should handle input for.
 
+`setActiveOnRegister`
+
+: `string` <span class="optional">optional</span>
+
+  Specifies whether KeymanWeb will set the newly registered keyboard as active. Default value `true`.
+
+  * If `true`, KeymanWeb will automatically activate a keyboard when registered.
+  * If `false`, KeymanWeb will not activate a keyboard when registered.
+
+`useAlerts`
+
+: `boolean` <span class="optional">optional</span>
+
+  Specifies whether KeymanWeb will display internal alerts. Default value `true`.
+
+  * If `true`, KeymanWeb will display internal alerts.
+  * If `false`, KeymanWeb will not display internal alerts. Choose this if you want to customize the alert messages for use on your site.
+
 `spacebarText`
 
 : `com.keyman.SpacebarText` <span class="optional">optional</span>

--- a/developer/engine/web/15.0/reference/keyboard_registration_errors.md
+++ b/developer/engine/web/15.0/reference/keyboard_registration_errors.md
@@ -1,0 +1,55 @@
+---
+title: Keyboard Registration Errors
+---
+
+If KeymanWeb has an error while adding/registering a keyboard, the `ErrorStub` object containing the following members is returned:
+
+`keyboard`
+
+: `object` <span class="optional">optional</span>
+
+  Information on the keyboard
+
+`language`
+
+: `object` <span class="optional">optional</span>
+
+  Information on the language associated with the keyboard
+
+`error`
+
+: `Error`
+
+  Javascript error that occurred during keyboard registration
+
+---
+
+The `ErrorStub.keyboard` object contains the following members:
+
+`id`
+
+: `string`
+
+ID (internal name) of keyboard
+
+`name`
+
+: `string`
+
+Name of the keyboard
+
+---
+
+The `ErrorStub.language` object contains the following members:
+
+`id`
+
+: `string`
+
+BCP 47 code for supported keyboard language. If a keyboard supports multiple languages, an array of ErrorStubs is returned.
+
+`name`
+
+: `string`
+
+Name of the language


### PR DESCRIPTION
This documents the change from keymanapp/keyman#5044 where KeymanWeb async API calls now return a promise.

Also reverts initialization options `setActiveOnRegister` and `useAlerts` that were inadvertently dropped in #432 when `init.php` was migrated to `init.md`