### PR TITLE
chore: Add kb article on installing for M1 Mac

### DIFF
--- a/knowledge-base/kb0107.md
+++ b/knowledge-base/kb0107.md
@@ -5,6 +5,8 @@ Keyman for macOS is currently built for x86 CPU, and not M1.
 If you're using an M1 Mac and experience an installation error about "Bad CPU type in executable", 
 the following steps will allow you to install Keyman for macOS:
 
+Note: This is a temporary fix until we release an M1 update with Keyman 15.
+
 1. Open Terminal.app
 2. Copy and Paste this command into Terminal.app
 ```

--- a/knowledge-base/kb0107.md
+++ b/knowledge-base/kb0107.md
@@ -1,0 +1,17 @@
+# HOWTO: Install Keyman for macOS on an M1 Mac
+
+Keyman for macOS is currently built for x86 CPU, and not M1.
+
+If you're using an M1 Mac and experience an installation error about "Bad CPU type in executable", 
+the following steps will allow you to install Keyman for macOS:
+
+1. Open Terminal.app
+2. Copy and Paste this command into Terminal.app
+```
+softwareupdate --install-rosetta
+```
+3. Hit <kbd>Return</kbd>
+4. When it says "Install of Rosetta 2 finished successfully", you may close Terminal.app and install Keyman
+
+After installing Keyman, you may need to set the security configurations for Keyman:
+[How to configure macOS security options for Keyman](/products/mac/current-version/troubleshooting/configure-security)


### PR DESCRIPTION
This adds a knowledge base article on installing Keyman for macOS on an M1.

Reference
https://community.software.sil.org/t/does-keyman-support-m1-mac/5213