### PR TITLE
chore: Update kb article on Keyman for macOS on M1

### DIFF
--- a/knowledge-base/kb0107.md
+++ b/knowledge-base/kb0107.md
@@ -1,11 +1,9 @@
 # HOWTO: Install Keyman for macOS on an M1 Mac
 
-Keyman for macOS is currently built for x86 CPU, and not M1.
+As of Keyman 14.0.282, Keyman for macOS is built for x86 CPU and M1.
 
-If you're using an M1 Mac and experience an installation error about "Bad CPU type in executable", 
+If you're using an older version of Keyman for macOS on an M1 Mac and experience an installation error about "Bad CPU type in executable", 
 the following steps will allow you to install Keyman for macOS:
-
-Note: This is a temporary fix until we release an M1 update with Keyman 15.
 
 1. Open Terminal.app
 2. Copy and Paste this command into Terminal.app


### PR DESCRIPTION
Documents M1 support from keymanapp/keyman#5737

> Note: https://help.keyman.com/knowledge-base/107 needs to be updated once this and a cherry-picked to 14 version are released.