### PR TITLE
docs: updated info on seralised input behaviour

### DIFF
--- a/knowledge-base/kb0097.md
+++ b/knowledge-base/kb0097.md
@@ -2,7 +2,9 @@
 
 ## Background
 
-When Keyman is running, it controls the keyboard input queue in Windows in order to guarantee the sequence of events. You should not normally need to change this behaviour; however it is possible to switch off the control of the keyboard input queue if you suspect a conflict with another utility. From version 15 if a Keyman keyboard is not active, keyman will disable the serialised input. If you are running an older version of Keyman upgrade to the latest version. If that does not resolve your issue then try disabling the serialised input as described below.   
+When Keyman is running, it controls the keyboard input queue in Windows in order to guarantee the sequence of events. You should not normally need to change this behaviour; however it is possible to switch off the control of the keyboard input queue if you suspect a conflict with another utility.
+
+From version 15, Keyman will enable serialised input only if a Keyman keyboard is active. If you are running an older version of Keyman, you should upgrade to the latest version. If that does not resolve your issue then try disabling the serialised input as described below.
  [Learn more...](https://blog.keyman.com/2018/10/the-keyman-keyboard-input-pipeline/)
 
 ---

--- a/knowledge-base/kb0097.md
+++ b/knowledge-base/kb0097.md
@@ -2,7 +2,8 @@
 
 ## Background
 
-When Keyman is running, it controls the keyboard input queue in Windows in order to guarantee the sequence of events. You should not normally need to change this behaviour; however it is possible to switch off the control of the keyboard input queue if you suspect a conflict with another utility. [Learn more...](https://blog.keyman.com/2018/10/the-keyman-keyboard-input-pipeline/)
+When Keyman is running, it controls the keyboard input queue in Windows in order to guarantee the sequence of events. You should not normally need to change this behaviour; however it is possible to switch off the control of the keyboard input queue if you suspect a conflict with another utility. From version 15 if a Keyman keyboard is not active, keyman will disable the serialised input. If you are running an older version of Keyman upgrade to the latest version. If that does not resolve your issue then try disabling the serialised input as described below.   
+ [Learn more...](https://blog.keyman.com/2018/10/the-keyman-keyboard-input-pipeline/)
 
 ---
 
@@ -15,19 +16,27 @@ When Keyman is running, it controls the keyboard input queue in Windows in order
 **Warning:** Serious problems might occur if you modify the registry incorrectly by using Registry Editor or by using another method. These problems might require that you reinstall the operating system. We cannot guarantee that these problems can be solved. Modify the registry at your own risk.
 
 ---
+## Keyman 14 or Later
 
-## Disable Serialised Input
-
+### **Disable Serialised Input**
+1. Open Keyman Configuration
+2. Select **Options / Keyman System Settings**
+3. For **engine.compatibility.serialize_input,** enter the value **0**.
+4. Restart Keyman
+### **Enable Serialised Input**
+1. Open Keyman Configuration
+2. Select **Options / Keyman System Settings**
+3. For **engine.compatibility.serialize_input,** enter the value **1**.
+4. Restart Keyman
+## Keyman 13 or Earlier                                                                            
+### **Disable Serialised Input**
 1. Start Registry Editor (regedit.exe)
 2. Navigate to `HKEY_CURRENT_USER\Software\Keyman\Keyman Engine`
 3. Select **Edit/New/Key** and name the key `Debug`.
 4. Select the new `Debug` key, and select **Edit/New/DWORD value** and name the value `Flag_ShouldSerializeInput`. It will be created with the default value `0`.
 5. Exit and restart Keyman (you may need to restart Windows).
 
----
-
-## Enable Serialised Input
-
+### **Enable Serialised Input**
 1. Start Registry Editor (regedit.exe)
 2. Navigate to `HKEY_CURRENT_USER\Software\Keyman\Keyman Engine\Debug`
 3. Delete the value `Flag_ShouldSerializeInput`.


### PR DESCRIPTION
From version 15 the seralized input pipline will not be active
if a Keyman keyboard is not active. Update the document to reflect this.