### PR TITLE
fix: help offset

### DIFF
--- a/cdn/dev/js/kbd-docs.js
+++ b/cdn/dev/js/kbd-docs.js
@@ -405,7 +405,7 @@ function loaded(){
     $('#toc-content').toc({
       'selectors': 'h1,h2,h3,h4',
       'container': 'article',
-      'scrollToOffset' : 120,
+      'scrollToOffset' : 40,
       'filter' : function(index, element) { return $(element).parents('.tip,.note').length == 0; }
     });
 
@@ -419,6 +419,13 @@ function loaded(){
 
     $('#toc').css('max-height', window.innerHeight-180 + 'px');
     scrollFix();
+
+    // If the location hash is a #toc- anchor, the browser won't scroll it
+    // into view on page load, because the anchor is defined too late. So let's
+    // scroll that anchor into view
+    if(location.hash.match(/#toc-[a-z0-9_-]+$/i)) {
+      $('a[href="'+location.hash+'"]').click();
+    }
   });
 
 }

--- a/cdn/dev/js/kmlive.js
+++ b/cdn/dev/js/kmlive.js
@@ -283,7 +283,7 @@ function loaded(){
     $('#toc-content').toc({
       'selectors': 'h1,h2,h3,h4',
       'container': 'article',
-      'scrollToOffset' : 120,
+      'scrollToOffset' : 40,
       'filter' : function(index, element) { return $(element).parents('.tip,.note,aside').length == 0; }
     });
 
@@ -297,6 +297,13 @@ function loaded(){
 
     $('#toc').css('max-height', window.innerHeight-180 + 'px');
     scrollFix();
+
+    // If the location hash is a #toc- anchor, the browser won't scroll it
+    // into view on page load, because the anchor is defined too late. So let's
+    // scroll that anchor into view
+    if(location.hash.match(/#toc-[a-z0-9_-]+$/i)) {
+      $('a[href="'+location.hash+'"]').click();
+    }
   });
 
 }


### PR DESCRIPTION
Relates to keymanapp/keyman#2750.

When you load a page with a `#toc-` hash, it would not scroll to the correct place in the document, because the `#toc-` anchors are all defined dynamically after page load.

This adds a slightly hacky fix to scroll the anchor into view, leveraging the existing toc elements to access the custom scroll code.

Note that this jquery code is all very old, but changing that is a much more significant update which needs site-wide consideration.