### PR TITLE
docs: clarify setup.exe must be unsigned

### DIFF
--- a/knowledge-base/kb0035.md
+++ b/knowledge-base/kb0035.md
@@ -50,6 +50,14 @@ By default, Setup will not install packages from the same folder as the installe
 
 If a zip file is appended to the setup executable (e.g. with `copy /b setup.exe+file.zip setup-file.exe`), then Setup will extract the contents of the zip file to a temporary folder and install the included components. This also requires a setup.inf file.
 
+**IMPORTANT:** You must use the unsigned setup.exe executable to create a
+combined installer. The version of setup.exe that is listed on the
+downloads.keyman.com site is signed, for general use. The unsigned executable is
+available in the Keyman Developer installation, under
+`%ProgramFiles(x86)%\Keyman\Keyman Developer\Redist\Setup`. Once you have
+combined the executable with the zip file, you can safely sign the resulting
+file.
+
 The zip file should include:
 
 1. setup.inf


### PR DESCRIPTION
This applies only to building self-extracting installers...