### PR TITLE
chore: Revert temporary use of 14.0

### DIFF
--- a/_includes/includes/head.php
+++ b/_includes/includes/head.php
@@ -99,7 +99,7 @@
     }
     if(!isset($kmw_dev_path)) {
   ?>
-      <script src='https://s.keyman.com/kmw/engine/14.0.294/keymanweb.js'></script>
+      <script src='https://s.keyman.com/kmw/engine/<?=$kmw_version_number?>/keymanweb.js'></script>
   <?php
     } else {
   ?>


### PR DESCRIPTION
Will revert keymanapp/help.keyman.com#561, once keymanapp/keyman#6817 (`stable-15.0` 🍒 of keymanapp/keyman#6793) has been released.