### PR TITLE
feat: Improve KB article

### DIFF
--- a/knowledge-base/kb0103.md
+++ b/knowledge-base/kb0103.md
@@ -23,7 +23,7 @@ sudo echo have sudo
 Next paste these commands:
 
 ```bash
-wget -qO - http://linux.lsdev.sil.org/downloads/sil-testing.gpg | sudo apt-key add -
+wget -qO - http://linux.lsdev.sil.org/downloads/sil-testing.gpg | sudo tee /etc/apt/trusted.gpg.d/linux-lsdev-sil-org.asc
 sudo add-apt-repository "deb http://linux.lsdev.sil.org/ubuntu $(lsb_release -sc)-experimental main"
 sudo apt-get update
 sudo apt-get install keyman onboard-keyman


### PR DESCRIPTION
Using apt-key is deprecated in Ubuntu 22.04+, resulting in an ugly warning when updating packages. This change documents the recommended way of adding a new key.