### PR TITLE
fix: :axe: Don't upper-case breadcrumb links

### DIFF
--- a/_includes/includes/kb_doc_template.php
+++ b/_includes/includes/kb_doc_template.php
@@ -96,7 +96,7 @@
     $crumbs = explode("/",$_SERVER["REQUEST_URI"]);
     $crumbcount = count($crumbs);
     for($i=0;$i<$crumbcount;$i++){
-      $crumb = ucfirst(str_replace(array(".php","_","-"),array(""," "," "),$crumbs[$i]) . ' ');
+      $crumb = str_replace(array(".php","_","-"),array(""," "," "),$crumbs[$i]) . ' ';
       if($i == 0){
         $crumbtrail = '<div id="breadcrumbTrail"><a href="/">help.keyman.com</a>';
       }elseif($i < $crumbcount){

--- a/_includes/includes/template.php
+++ b/_includes/includes/template.php
@@ -103,7 +103,7 @@
     $crumbcount = count($crumbs);
     $crumbtrail = '';
     for($i=1; $i<$crumbcount; $i++){
-      $crumb = ucfirst(str_replace(array(".php","_","-"),array(""," "," "),$crumbs[$i]) . ' ');
+      $crumb = str_replace(array(".php","_","-"),array(""," "," "),$crumbs[$i]) . ' ';
 
       $urlCount = $crumbcount - $i -1;
       $url = '';


### PR DESCRIPTION
Part of the :axe: chain for #588 

Since filenames on Linux are case-sensitive, this removes upper-casing bread crumb links.

### Sample Screenshots of Updated Links
http://help.keyman.com.local/developer/9.0/guides/intro
![products no uc](https://user-images.githubusercontent.com/7358010/187119623-a582146a-59b5-47e4-96bd-368831369e50.png)

http://help.keyman.com.local/developer/engine/android/current-version/guides/in-app/
![engine no uc](https://user-images.githubusercontent.com/7358010/187119630-34179fae-b3f3-4b6c-b8ea-494b730cd7e5.png)

