### PR TITLE
fix: Include requested URI on 404 error 🦭

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -13,8 +13,9 @@ RewriteBase /
 <If "%{REQUEST_SCHEME} == 'http' && %{HTTP_HOST} == 'help.keyman.com' && %{REQUEST_URI} !~ m#^/.well-known/(.*)$#" >
     Redirect "/" "https://help.keyman.com"
 </If>
-# Custom error messages
-ErrorDocument 404 /_includes/errors/404.php
+
+# Custom error messages (need to pass the original request)
+ErrorDocument 404 /_includes/errors/404.php?uri=%{REQUEST_URI}
 
 # Handle IIS bug which created links to /DEVELOPER instead of /developer
 RedirectMatch "/DEVELOPER(.*)" "/developer$1"

--- a/_includes/errors/404.php
+++ b/_includes/errors/404.php
@@ -6,7 +6,8 @@
     'index' => false
   ]);
   
-  $page = empty($_REQUEST['uri']) ? '' : $_REQUEST['uri'];
+  // IIS uses REQUEST_URI; Apache using uri
+  $page = empty($_REQUEST['uri']) ? $_SERVER["REQUEST_URI"] : $_REQUEST['uri'];
   
   function E($v)
   {

--- a/_includes/errors/404.php
+++ b/_includes/errors/404.php
@@ -3,10 +3,10 @@
 
   head([
     'title' => "Page not found",
-    'index' => false   
+    'index' => false
   ]);
   
-  $page = $_SERVER["REQUEST_URI"];
+  $page = empty($_REQUEST['uri']) ? '' : $_REQUEST['uri'];
   
   function E($v)
   {


### PR DESCRIPTION
Follow-on to #588

On Apache, this passes the requested URI for 404 errors. (IIS still using REQUEST_URI)

afaict, Apache redirects ErrorDocument so the original code:

```
$page = $_SERVER["REQUEST_URI"]
```
was displaying the path to the 404.php page.

atm I don't know how to prevent the addressbar from updating
e.g.
http://localhost.8055/bogus results in
http://localhost:8055/_includes/errors/404?uri=/bogus