### PR TITLE
Add a /api/deploy endpoint for the k8s hosted site

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,3 +36,45 @@ After this, you can access the help.keyman site at http://localhost:8055
 #### Running tests
 Checks for broken links
 1. Run `./build.sh test`
+
+## How to run help.keyman.com locally with Docker Desktop's Kubernetes singlenode cluster
+
+For testing Kubernetes deployment there are yaml files under `resources/kubectl`, that cover local developer testing. 
+
+### Pre-requisites
+On the host machine, install [Docker](https://docs.docker.com/get-docker/), then enable Kubernetes in the settings.
+
+Ensure you have built a help-keyman-app Docker image, and either tag it `docker.dallas.languagetechnology.org/keyman/help-keyman-app` or modify the `app-php` containers `image:` value to match you localy copies name.
+
+To deploy the dev version to the cluster do the following:
+1. Ensure your `kubectl` context is set to `docker-desktop`, though the Docker Desktop systray icon or running: 
+```bash
+$> kubectl config use-context docker-desktop
+```
+2. Create a keyman namespace if it does not already exist:
+```bash
+$> kubectl create ns keyman
+```
+3. Apply the configs for the resources and start the pod:
+```bash
+$> kubectl --namespace keyman apply \
+       -f resources/kubectl/help-kubectl-dev.yaml \
+       -f resources/kubectl/help-kubectl.yaml
+```
+The site can be reached on http://localhost:30080/ via web browser, and the deploy api is on http://localhost:30900/api/deploy, and can be activated like so:
+```bash
+$> curl -v --request POST \
+    -H "Content-Type: application/json" \
+    -H "X-Hub-Signature-256: sha256=49af8531106a369bfee369f91dadec597e8ea3992ec2802bbe655be0ece17f15" \
+    --data '{"action":"push","ref":"refs/heads/staging"}' \
+    http://localhost:30900/api/deploy
+```
+This simulates enough of GitHub webhook event, to pass validation on the responder.
+4. Remove the k8s pod and resources, to delete everything do:
+```bash
+$> kubectl --namespace=keyman delete {pod,cm,svc,secret,pvc}/help-keyman-com
+```
+Or just delete the pod and keep the resources for further testing:
+```bash
+$> kubectl --namespace=keyman delete pod/help-keyman-com
+```

--- a/Readme.md
+++ b/Readme.md
@@ -37,17 +37,17 @@ After this, you can access the help.keyman site at http://localhost:8055
 Checks for broken links
 1. Run `./build.sh test`
 
+
 ## How to run help.keyman.com locally with Docker Desktop's Kubernetes singlenode cluster
 
 For testing Kubernetes deployment there are yaml files under `resources/kubectl`, that cover local developer testing. 
 
 ### Pre-requisites
-On the host machine, install [Docker](https://docs.docker.com/get-docker/), then enable Kubernetes in the settings.
+On the host machine, install [Docker](https://docs.docker.com/get-docker/), then enable Kubernetes in the settings. Ensure you have built a help-keyman-app Docker image, and either tag it `docker.dallas.languagetechnology.org/keyman/help-keyman-app` or modify the `app-php` containers `image:` value to match you local copy's name.
 
-Ensure you have built a help-keyman-app Docker image, and either tag it `docker.dallas.languagetechnology.org/keyman/help-keyman-app` or modify the `app-php` containers `image:` value to match you localy copies name.
-
+### Deploying to a desktop cluster
 To deploy the dev version to the cluster do the following:
-1. Ensure your `kubectl` context is set to `docker-desktop`, though the Docker Desktop systray icon or running: 
+1. Ensure your `kubectl` context is set to `docker-desktop`, though the Docker Desktop systray icon or by running:  
 ```bash
 $> kubectl config use-context docker-desktop
 ```
@@ -61,6 +61,7 @@ $> kubectl --namespace keyman apply \
        -f resources/kubectl/help-kubectl-dev.yaml \
        -f resources/kubectl/help-kubectl.yaml
 ```
+### Testing the site and `/api/deploy` webhook endpoint
 The site can be reached on http://localhost:30080/ via web browser, and the deploy api is on http://localhost:30900/api/deploy, and can be activated like so:
 ```bash
 $> curl -v --request POST \
@@ -69,8 +70,11 @@ $> curl -v --request POST \
     --data '{"action":"push","ref":"refs/heads/staging"}' \
     http://localhost:30900/api/deploy
 ```
-This simulates enough of GitHub webhook event, to pass validation on the responder.
-4. Remove the k8s pod and resources, to delete everything do:
+This simulates enough of a GitHub webhook push event to pass validation on the responder.
+
+### Clean up after testing
+
+To remove the k8s pod and resources, and delete everything do:
 ```bash
 $> kubectl --namespace=keyman delete {pod,cm,svc,secret,pvc}/help-keyman-com
 ```

--- a/resources/kubectl/help-kubectl-deploy.yaml
+++ b/resources/kubectl/help-kubectl-deploy.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: help-keyman-com
+  namespace: keyman
+  finalizers:
+  - kubernetes.io/pvc-protection
+spec:
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: help-keyman-com
+  name: help-keyman-com
+  namespace: keyman
+spec:
+  type: NodePort
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+  - name: api
+    port: 9000
+    protocol: TCP
+  selector:
+    run: help-keyman-com
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: help-keyman-com
+  namespace: keyman
+spec:
+  rules:
+  - host: help.keyman-staging.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: help-keyman-com
+            port:
+              name: http
+      - path: /api/deploy
+        pathType: Exact
+        backend:
+          service:
+            name: help-keyman-com
+            port:
+              name: api
+  - host: com-keyman-help.languagetechnology.org
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: help-keyman-com
+            port:
+              name: http
+      - path: /api/deploy
+        pathType: Exact
+        backend:
+          service:
+            name: help-keyman-com
+            port:
+              name: api

--- a/resources/kubectl/help-kubectl-dev.yaml
+++ b/resources/kubectl/help-kubectl-dev.yaml
@@ -19,6 +19,9 @@ metadata:
   name: help-keyman-com
   namespace: keyman
 data:
+  # This key is for local testing, or development of k8s yaml files 
+  # on a test cluster (e.g. minikude etc). Do *not* deploy to production
+  # decoded it is: 7f913e60-f9ba-430b-9231-91908fa6c06b
   deploy_key: N2Y5MTNlNjAtZjliYS00MzBiLTkyMzEtOTE5MDhmYTZjMDZi
 type: Opaque  
 ---

--- a/resources/kubectl/help-kubectl-dev.yaml
+++ b/resources/kubectl/help-kubectl-dev.yaml
@@ -14,6 +14,15 @@ spec:
       storage: 1Gi
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: help-keyman-com
+  namespace: keyman
+data:
+  deploy_key: N2Y5MTNlNjAtZjliYS00MzBiLTkyMzEtOTE5MDhmYTZjMDZi
+type: Opaque  
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -27,6 +36,10 @@ spec:
     port: 80
     protocol: TCP
     nodePort: 30080
+  - name: api
+    port: 9000
+    protocol: TCP
+    nodePort: 30900
   selector:
     run: help-keyman-com
 

--- a/resources/kubectl/help-kubectl.yaml
+++ b/resources/kubectl/help-kubectl.yaml
@@ -9,7 +9,7 @@ spec:
   terminationGracePeriodSeconds: 60
   containers:
   - name: app-php
-    image: help-keyman-website
+    image: docker.dallas.languagetechnology.org/keyman/help-keyman-app
     imagePullPolicy: IfNotPresent
     ports:
     - containerPort: 80
@@ -25,46 +25,64 @@ spec:
     livenessProbe:
       tcpSocket:
         port: 80
-  - name: updater
-    image: bitnami/git
+
+  - name: api
+    image: almir/webhook
     imagePullPolicy: IfNotPresent
     env:
-    - name: UPDATE_POLL
-      value: "900"
-    command: ["sh", "-c"]
+    - name: DEPLOY_KEY
+      valueFrom:
+        secretKeyRef:
+          name: help-keyman-com
+          key: deploy_key
+    - name: SITE_GIT_BRANCH
+      valueFrom:
+        configMapKeyRef:
+          name: help-keyman-com
+          key: site-branch
     args:
-    - |
-      cd /mnt
-      git fetch && git reset --hard HEAD
-      while sleep ${UPDATE_POLL}; do
-        git fetch && git reset --hard HEAD
-      done
+    - -verbose
+    - -urlprefix=api
+    - -template
+    - -hooks=/webhooks/hooks.yaml
     lifecycle:
-      preStop:
+      postStart:
         exec:
-          command: ["/usr/bin/pkill", "sleep"]
+          command: ["/sbin/apk", "add", "git"]
+    ports:
+    - containerPort: 9000
     volumeMounts:
+    - name: webhooks
+      mountPath: /webhooks
+      readOnly: true
     - name: help-site-app
       mountPath: /mnt
+
   initContainers:
   - name: init-site-data
     image: bitnami/git
     imagePullPolicy: IfNotPresent
     env:
     - name: SITE_GIT_BRANCH
-      value: staging
-#      value: master
+      valueFrom:
+        configMapKeyRef:
+          name: help-keyman-com
+          key: site-branch
     command: ["sh", "-c"]
     args:
     - |
+      test -d /mnt/.git && exit 0
+      set -e
       cd /mnt
-      test -d .git && exit 0
       echo Initial clone
       git clone \
         --filter=blob:none \
         --no-checkout \
         --branch=${SITE_GIT_BRANCH} \
-        https://github.com/keymanapp/help.keyman.com.git ./
+        https://github.com/keymanapp/help.keyman.com.git \
+        .toplevel
+      mv .toplevel/.git ./
+      rmdir .toplevel
       echo Configure sparse-checkout
       git sparse-checkout set --no-cone \
         "/*"              \
@@ -75,6 +93,7 @@ spec:
         "!Dockerfile"     \
         "!Readme.md"      \
         "!web.config"
+      git checkout
       echo Link vendored PHP
       ln -sf /var/www/vendor vendor
     volumeMounts:
@@ -84,4 +103,55 @@ spec:
   - name: help-site-app
     persistentVolumeClaim:
       claimName: help-keyman-com
-
+  - name: webhooks
+    configMap:
+      name: help-keyman-com
+      items:
+      - key: deployer
+        path: deploy.sh
+        mode: 0555
+      - key: webhooks
+        path: hooks.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: help-keyman-com
+  namespace: keyman
+data:
+  site-branch: staging
+  deployer: |
+    #!/bin/sh
+    git fetch && git reset --hard HEAD
+  webhooks: |
+    - id: deploy
+      execute-command: /webhooks/deploy.sh
+      command-working-directory: /mnt
+      http-methods: [POST]
+      trigger-rule:
+        and:
+        - or:
+          - match:
+              type: payload-hmac-sha256
+              secret: '{{ getenv "DEPLOY_KEY" }}'
+              parameter:
+                source: header
+                name: X-Hub-Signature-256
+          - match:
+              type: payload-hmac-sha1
+              secret: '{{ getenv "DEPLOY_KEY" }}'
+              parameter:
+                source: header
+                name: X-Hub-Signature
+        - match:
+            type: value
+            value: push
+            parameter:
+              source: payload
+              name: action
+        - match:
+            type: value
+            value: 'refs/heads/{{getenv "SITE_GIT_BRANCH"}}'
+            parameter:
+              source: payload
+              name: ref


### PR DESCRIPTION
This implements a deploy webhook by having a dedicated small responder directly perform a git pull. It turns out to be less trouble than watching for files in sidecar container, and more efficient than polling in a bash script signal files. This only maps the /api/deploy path to respond to GH push webhook events, leaving the rest of the '/api' space for the site's php. It is integrated to pull the secret from k8s a Secret volume (not defined here) and configuration (branch name to deploy, deploy script, and responder config) from k8s ConfigMap (included).
