### PR TITLE
chore: Fix links to km_kbp_state

### DIFF
--- a/developer/core/desktop/15.0/c-api/index.php
+++ b/developer/core/desktop/15.0/c-api/index.php
@@ -418,7 +418,7 @@ km_kbp_get_engine_attrs(km_kbp_state const *state);
       <dt id="state"><code class="token symbol">state</code></dt>
       <dd>
         An opaque pointer to an
-        <a href="#km_kbp_state"><code class="token symbol">km_kbp_state</code></a>.
+        <a href="state-api#state"><code class="token symbol">km_kbp_state</code></a>.
       </dd>
     </dl>
   </section>

--- a/developer/core/desktop/16.0/c-api/index.php
+++ b/developer/core/desktop/16.0/c-api/index.php
@@ -418,7 +418,7 @@ km_kbp_get_engine_attrs(km_kbp_state const *state);
       <dt id="state"><code class="token symbol">state</code></dt>
       <dd>
         An opaque pointer to an
-        <a href="#km_kbp_state"><code class="token symbol">km_kbp_state</code></a>.
+        <a href="state-api#state"><code class="token symbol">km_kbp_state</code></a>.
       </dd>
     </dl>
   </section>


### PR DESCRIPTION
Maybe fixes #668 

I don't see a section for `km_kbp_state` from the c-api page. Maybe it goes to `state-api#state`?
