### PR TITLE
docs: add parens and type clarifications to Core headings

### DIFF
--- a/developer/core/desktop/15.0/c-api/context-api.php
+++ b/developer/core/desktop/15.0/c-api/context-api.php
@@ -689,7 +689,7 @@ km_kbp_context_shrink(km_kbp_context *context,
   <section class="description">
     <h2>Description</h2>
     <p>
-      Return the length of a terminated 
+      Return the length of a terminated
       <a href="#km_kbp_context_item"><code class="token constant">km_kbp_context_item</code></a>
       array.
     </p>
@@ -705,7 +705,7 @@ km_kbp_context_item_list_size(km_kbp_context_item const *context_items);
     <dl>
       <dt id="context_items"><code class="token symbol">context_items</code></dt>
       <dd>
-      A pointer to a 
+      A pointer to a
         <a href="#KM_KBP_CT_END"><code class="token constant">KM_KBP_CT_END</code></a>
         terminated array of
         <a href="#km_kbp_context_item"><code class="token symbol">km_kbp_context_item</code></a>

--- a/developer/core/desktop/15.0/c-api/keyboard-api.php
+++ b/developer/core/desktop/15.0/c-api/keyboard-api.php
@@ -111,7 +111,7 @@ typedef struct {
 
       <dt id="function_name"><code class="token symbol">function_name</code></dt>
       <dd> IMX function name  </dd>
-      
+
       <dt id="imx_id"><code class="token symbol">imx_id</code></dt>
       <dd> unique identifier used to call this function </dd>
 
@@ -274,7 +274,7 @@ km_kbp_keyboard_get_key_list(km_kbp_keyboard const *keyboard,
 
       <dt id="out"><code class="token symbol">out</code></dt>
       <dd>
-        A pointer to the result, an array of 
+        A pointer to the result, an array of
         <a href="#km_kbp_keyboard_key"><code class="token symbol">km_kbp_keyboard_keys</code></a>
       </dd>
     </dl>
@@ -297,7 +297,7 @@ km_kbp_keyboard_get_key_list(km_kbp_keyboard const *keyboard,
     <h2>Description</h2>
     <p>
     Free the allocated memory belonging to a keyboard key list previously
-    returned by <a href="#km_kbp_keyboard_get_key_list"><code class="token symbol">km_kbp_keyboard_get_key_list</code></a>      
+    returned by <a href="#km_kbp_keyboard_get_key_list"><code class="token symbol">km_kbp_keyboard_get_key_list</code></a>
     </p>
   </section>
   <section class="specification">
@@ -322,13 +322,14 @@ km_kbp_keyboard_get_key_list(km_kbp_keyboard const *keyboard,
     <h2>Description</h2>
     <p>
     Returns the list of IMX libraries and function names that are referenced by
-    the keyboard. The matching dispose call needs to be called to free the memory.
+    the keyboard. The matching dispose call <a href="#km_kbp_keyboard_imx_list_dispose"><code class="token symbol">km_kbp_keyboard_imx_list_dispose</code></a>
+    needs to be called to free the memory.
     </p>
   </section>
   <section class="specification">
     <h2>Specification</h2>
 <pre><code class="language-c">km_kbp_status km_kbp_keyboard_get_imx_list(
-                              km_kbp_keyboard const *keyboard, 
+                              km_kbp_keyboard const *keyboard,
                               km_kbp_keyboard_imx** imx_list);
 
 </code></pre>
@@ -341,7 +342,7 @@ km_kbp_keyboard_get_key_list(km_kbp_keyboard const *keyboard,
 
       <dt id="imx_list"><code class="token symbol">imx_list</code></dt>
       <dd>
-        A pointer to the result, an array of 
+        A pointer to the result, an array of
         <a href="#km_kbp_keyboard_imx"><code class="token symbol">km_kbp_keyboard_imx</code></a>
         structure.
       </dd>
@@ -365,7 +366,7 @@ km_kbp_keyboard_get_key_list(km_kbp_keyboard const *keyboard,
     <h2>Description</h2>
     <p>
     Free the allocated memory belonging to a IMX list previously
-returned by <a href="#km_kbp_keyboard_imx_list_dispose"><code class="token symbol">km_kbp_keyboard_imx_list_dispose</code></a>.
+returned by <a href="#km_kbp_keyboard_get_imx_list"><code class="token symbol">km_kbp_keyboard_get_imx_list</code></a>.
     </p>
   </section>
   <section class="specification">

--- a/developer/core/desktop/15.0/c-api/state-api.php
+++ b/developer/core/desktop/15.0/c-api/state-api.php
@@ -60,16 +60,16 @@ head([
       <dd>A marker value, only meaningful to an engine.</dd>
 
       <dt id="opt"><code class="token symbol">option</code></dt>
-      
+
       <dt id="character"><code class="token symbol">character</code></dt>
       <dd>A Unicode Scalar Value.</dd>
-      
+
       <dt id="capsLock"><code class="token symbol">capsLock</code></dt>
       <dd>CAPSLOCK type, 1 to turn on, 0 to turn off.</dd>
-      
+
       <dt id="backspace"><code class="token symbol">backspace</code></dt>
       <dd>Backspace type, Unknown, Character, Marker</dd>
-      
+
       <dd>
         A pointer to
         <a href="#km_kbp_option_item"><code class="token symbol">km_kbp_option_item</code></a>
@@ -481,10 +481,10 @@ km_kbp_process_event(km_kbp_state *state,
         <a href="#km_kbp_modifier_state"><code class="token symbol">km_kbp_modifier_state</code></a>
         enum.
       </dd>
-      
+
       <dt id="is_key_down"><code class="token symbol">is_key_down</code></dt>
       <dd>
-        If the key is down value is > 0. 
+        If the key is down value is > 0.
       </dd>
     </dl>
   </section>
@@ -514,7 +514,7 @@ km_kbp_process_event(km_kbp_state *state,
     <p>
       Process the keyboard processors queued actions for the opaque state object.
       Updates the state object as appropriate and fills out its action list.
-      The client can add actions externally via the 
+      The client can add actions externally via the
       <a href="#km_kbp_state_queue_action_items"><code class="token symbol">km_kbp_state_queue_action_items</code></a>
       and then request the processing of the actions with this method.
     </p>
@@ -594,8 +594,8 @@ km_kbp_state_context(km_kbp_state *state);
   <section class="specification">
     <h2>Specification</h2>
 <pre><code class="language-c">void km_kbp_state_imx_register_callback(
-                                                  km_kbp_state *state, 
-                                                  km_kbp_keyboard_imx_platform imx_callback, 
+                                                  km_kbp_state *state,
+                                                  km_kbp_keyboard_imx_platform imx_callback,
                                                   void *callback_object);
 </code></pre>
   </section>
@@ -613,7 +613,7 @@ km_kbp_state_context(km_kbp_state *state);
         callback object
       </dd>
     </dl>
-  </section>  
+  </section>
 </article>
 
 <article id="km_kbp_state_imx_deregister_callback">
@@ -644,7 +644,7 @@ km_kbp_state_context(km_kbp_state *state);
     <h2>Description</h2>
     <p>
     Queue actions for the current keyboard processor state; normally
-    used in IMX callbacks called during 
+    used in IMX callbacks called during
     <a href="#km_kbp_process_event"><code class="token symbol">km_kbp_process_event</code></a>.
     </p>
   </section>
@@ -659,8 +659,8 @@ km_kbp_state_context(km_kbp_state *state);
       <dt id="state"><code class="token symbol">state</code></dt>
       <dd>A pointer to the opaque state object.</dd>
       <dt id="action_items"><code class="token symbol">action_items</code></dt>
-      <dd> The action items to be added to the keyboardprocessor queue. Must be terminated with a 
-      <a href="#KM_KBP_IT_END"><code class="token constant">KM_KBP_IT_END</code></a>  
+      <dd> The action items to be added to the keyboardprocessor queue. Must be terminated with a
+      <a href="#KM_KBP_IT_END"><code class="token constant">KM_KBP_IT_END</code></a>
        entry.</dd>
     </dl>
   </section>
@@ -670,12 +670,12 @@ km_kbp_state_context(km_kbp_state *state);
 
       <dt id="KM_KBP_STATUS_OK"><code class="token constant">KM_KBP_STATUS_OK</code></dt>
       <dd>On success.</dd>
-        
+
       <dt id="KM_KBP_STATUS_INVALID_ARGUMENT"><code class="token constant">KM_KBP_STATUS_INVALID_ARGUMENT</code></dt>
       <dd>
         In the event the
         <a href="#state"><code class="token symbol">state</code></a>
-        or 
+        or
         <a href="#km_kbp_action_item"><code class="token symbol">action_items</code></a>
          pointer is null.
       </dd>

--- a/developer/core/desktop/16.0/c-api/context-api.php
+++ b/developer/core/desktop/16.0/c-api/context-api.php
@@ -683,3 +683,40 @@ km_kbp_context_shrink(km_kbp_context *context,
     </dl>
   </section>
 </article>
+
+<article id="km_kbp_context_item_list_size">
+  <h1>km_kbp_context_item_list_size()</h1>
+  <section class="description">
+    <h2>Description</h2>
+    <p>
+      Return the length of a terminated
+      <a href="#km_kbp_context_item"><code class="token constant">km_kbp_context_item</code></a>
+      array.
+    </p>
+  </section>
+  <section class="specification">
+    <h2>Specification</h2>
+<pre><code class="language-c">size_t
+km_kbp_context_item_list_size(km_kbp_context_item const *context_items);
+</code></pre>
+  </section>
+  <section class="parameters">
+    <h2>Parameters</h2>
+    <dl>
+      <dt id="context_items"><code class="token symbol">context_items</code></dt>
+      <dd>
+      A pointer to a
+        <a href="#KM_KBP_CT_END"><code class="token constant">KM_KBP_CT_END</code></a>
+        terminated array of
+        <a href="#km_kbp_context_item"><code class="token symbol">km_kbp_context_item</code></a>
+        values.
+      </dd>
+    </dl>
+  </section>
+  <section class="returns">
+    <h2>Returns</h2>
+    <p>The number of items in the list, not including terminating item,
+      or 0 if <code class="token constant">context_items</code>
+      is null.</p>
+  </section>
+</article>

--- a/developer/core/desktop/16.0/c-api/context-api.php
+++ b/developer/core/desktop/16.0/c-api/context-api.php
@@ -30,7 +30,7 @@ head([
 
 
 <article id="km_kbp_context_type">
-  <h1>km_kbp_context_type</h1>
+  <h1>km_kbp_context_type enum</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -75,7 +75,7 @@ head([
 
 
 <article id="km_kbp_context_item">
-  <h1>km_kbp_context_item</h1>
+  <h1>km_kbp_context_item struct</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -124,7 +124,7 @@ head([
 </article>
 
 <article id="KM_KBP_CONTEXT_ITEM_END">
-  <h1>KM_KBP_CONTEXT_ITEM_END</h1>
+  <h1>KM_KBP_CONTEXT_ITEM_END macro</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -141,7 +141,7 @@ head([
 
 
 <article id="km_kbp_context_items_from_utf16">
-  <h1>km_kbp_context_items_from_utf16</h1>
+  <h1>km_kbp_context_items_from_utf16()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -200,7 +200,7 @@ km_kbp_context_items_from_utf16(km_kbp_cp const *text,
 
 
 <article id="km_kbp_context_items_from_utf8">
-  <h1>km_kbp_context_items_from_utf8</h1>
+  <h1>km_kbp_context_items_from_utf8()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -250,7 +250,7 @@ km_kbp_context_items_from_utf8(char const *text,
 
 
 <article id="km_kbp_context_items_to_utf16">
-  <h1>km_kbp_context_items_to_utf16</h1>
+  <h1>km_kbp_context_items_to_utf16()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -316,7 +316,7 @@ km_kbp_context_items_to_utf16(km_kbp_context_item const *item,
 
 
 <article id="km_kbp_context_items_to_utf8">
-  <h1>km_kbp_context_items_to_utf8</h1>
+  <h1>km_kbp_context_items_to_utf8()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -382,7 +382,7 @@ km_kbp_context_items_to_utf8(km_kbp_context_item const *item,
 
 
 <article id="km_kbp_context_items_dispose">
-  <h1>km_kbp_context_items_dispose</h1>
+  <h1>km_kbp_context_items_dispose()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -415,7 +415,7 @@ km_kbp_context_items_dispose(km_kbp_context_item *context_items);
 
 
 <article id="km_kbp_context_set">
-  <h1>km_kbp_context_set</h1>
+  <h1>km_kbp_context_set()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -467,7 +467,7 @@ km_kbp_context_set(km_kbp_context *context,
 
 
 <article id="km_kbp_context_get">
-  <h1>km_kbp_context_get</h1>
+  <h1>km_kbp_context_get()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -523,7 +523,7 @@ km_kbp_context_get(km_kbp_context const *context_items,
 
 
 <article id="km_kbp_context_clear">
-  <h1>km_kbp_context_clear</h1>
+  <h1>km_kbp_context_clear()</h1>
     <section class="description">
     <h2>Description</h2>
     <p>
@@ -548,7 +548,7 @@ km_kbp_context_clear(km_kbp_context *context);
 
 
 <article id="km_kbp_context_length">
-  <h1>km_kbp_context_length</h1>
+  <h1>km_kbp_context_length()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>Return the number of items in the context.</p>
@@ -577,7 +577,7 @@ km_kbp_context_length(km_kbp_context *);
 
 
 <article id="km_kbp_context_append">
-  <h1>km_kbp_context_append</h1>
+  <h1>km_kbp_context_append()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -628,7 +628,7 @@ km_kbp_context_append(km_kbp_context *context,
 </article>
 
 <article id="km_kbp_context_shrink">
-  <h1>km_kbp_context_shrink</h1>
+  <h1>km_kbp_context_shrink()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>

--- a/developer/core/desktop/16.0/c-api/index.php
+++ b/developer/core/desktop/16.0/c-api/index.php
@@ -227,7 +227,7 @@ head([
 </article>
 
 <article id="km_kbp_status_codes">
-  <h1>km_kbp_status_codes</h1>
+  <h1>km_kbp_status_codes enum</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -302,7 +302,7 @@ head([
 
 
 <article id="km_kbp_attr">
-  <h1>km_kbp_attr</h1>
+  <h1>km_kbp_attr struct</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -352,7 +352,7 @@ head([
 
 
 <article id="km_kbp_tech_value">
-  <h1>km_kbp_tech_value</h1>
+  <h1>km_kbp_tech_value enum</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -396,7 +396,7 @@ head([
 
 
 <article id="km_kbp_get_engine_attrs">
-  <h1>km_kbp_get_engine_attrs</h1>
+  <h1>km_kbp_get_engine_attrs()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>

--- a/developer/core/desktop/16.0/c-api/keyboard-api.php
+++ b/developer/core/desktop/16.0/c-api/keyboard-api.php
@@ -58,6 +58,66 @@ typedef struct {
   </section>
 </article>
 
+<article id="km_kbp_keyboard_key">
+  <h1>km_kbp_keyboard_key struct</h1>
+  <section class="description">
+    <h2>Description</h2>
+    <p>A structure pairing a virtual key and modifier</p>
+  </section>
+  <section class="specification">
+    <h2>Specification</h2>
+<pre><code class="language-c">
+typedef struct {
+  km_kbp_virtual_key key;
+  uint32_t modifier_flag;
+} km_kbp_keyboard_key;
+</code></pre>
+  </section>
+  <section class="members">
+    <h2>Members</h2>
+    <dl>
+      <dt id="key"><code class="token symbol">key</code></dt>
+      <dd> a virtual key code </dd>
+
+      <dt id="modifier_flag"><code class="token symbol">modifier_flag</code></dt>
+      <dd>The modifier flag </dd>
+
+    </dl>
+  </section>
+</article>
+
+<article id="km_kbp_keyboard_imx">
+  <h1>km_kbp_keyboard_imx struct</h1>
+  <section class="description">
+    <h2>Description</h2>
+    <p>A structure of IMX library and function name associated with an unique id</p>
+  </section>
+  <section class="specification">
+    <h2>Specification</h2>
+<pre><code class="language-c">
+typedef struct {
+  km_kbp_cp const * library_name;
+  km_kbp_cp const * function_name;
+  uint32_t imx_id;
+} km_kbp_keyboard_imx;
+
+</code></pre>
+  </section>
+  <section class="members">
+    <h2>Members</h2>
+    <dl>
+      <dt id="library_name"><code class="token symbol">library_name</code></dt>
+      <dd> IMX library name </dd>
+
+      <dt id="function_name"><code class="token symbol">function_name</code></dt>
+      <dd> IMX function name  </dd>
+
+      <dt id="imx_id"><code class="token symbol">imx_id</code></dt>
+      <dd> unique identifier used to call this function </dd>
+
+    </dl>
+  </section>
+</article>
 
 <article id="km_kbp_keyboard_load">
   <h1>km_kbp_keyboard_load()</h1>
@@ -185,6 +245,142 @@ km_kbp_keyboard_get_attrs(km_kbp_keyboard const *keyboard,
 
       <dt id="KM_KBP_STATUS_INVALID_ARGUMENT"><code class="token constant">KM_KBP_STATUS_INVALID_ARGUMENT</code></dt>
       <dd>If non-optional parameters are null.</dd>
+    </dl>
+  </section>
+</article>
+
+<article id="km_kbp_keyboard_get_key_list">
+  <h1>km_kbp_keyboard_get_key_list()</h1>
+  <section class="description">
+    <h2>Description</h2>
+    <p>
+    Returns the unordered full set of modifier + virtual keys that are handled by the
+keyboard. The matching dispose call needs to be called to free the memory.
+    </p>
+  </section>
+  <section class="specification">
+    <h2>Specification</h2>
+<pre><code class="language-c">km_kbp_status
+km_kbp_keyboard_get_key_list(km_kbp_keyboard const *keyboard,
+                            km_kbp_keyboard_key const **out);
+
+</code></pre>
+  </section>
+  <section class="parameters">
+    <h2>Parameters</h2>
+    <dl>
+      <dt id="keyboard"><code class="token symbol">keyboard</code></dt>
+      <dd>A pointer to the opaque keyboard object to be queried.</dd>
+
+      <dt id="out"><code class="token symbol">out</code></dt>
+      <dd>
+        A pointer to the result, an array of
+        <a href="#km_kbp_keyboard_key"><code class="token symbol">km_kbp_keyboard_keys</code></a>
+      </dd>
+    </dl>
+  </section>
+  <section class="returns">
+    <h2>Returns</h2>
+    <dl>
+      <dt id="KM_KBP_STATUS_OK"><code class="token constant">KM_KBP_STATUS_OK</code></dt>
+      <dd>On success.</dd>
+
+      <dt id="KM_KBP_STATUS_INVALID_ARGUMENT"><code class="token constant">KM_KBP_STATUS_INVALID_ARGUMENT</code></dt>
+      <dd>If non-optional parameters are null.</dd>
+    </dl>
+  </section>
+</article>
+
+<article id="km_kbp_keyboard_key_list_dispose">
+  <h1>km_kbp_keyboard_key_list_dispose()</h1>
+  <section class="description">
+    <h2>Description</h2>
+    <p>
+    Free the allocated memory belonging to a keyboard key list previously
+    returned by <a href="#km_kbp_keyboard_get_key_list"><code class="token symbol">km_kbp_keyboard_get_key_list</code></a>
+    </p>
+  </section>
+  <section class="specification">
+    <h2>Specification</h2>
+<pre><code class="language-c">void km_kbp_keyboard_key_list_dispose(km_kbp_keyboard_key *key_list);
+
+</code></pre>
+  </section>
+  <section class="parameters">
+    <h2>Parameters</h2>
+    <dl>
+      <dt id="keyboard"><code class="token symbol">keyboard</code></dt>
+      <dd>A pointer to the keyboard key list to be
+    disposed of.</dd>
+    </dl>
+  </section>
+</article>
+
+<article id="km_kbp_keyboard_get_imx_list">
+  <h1>km_kbp_keyboard_get_imx_list()</h1>
+  <section class="description">
+    <h2>Description</h2>
+    <p>
+    Returns the list of IMX libraries and function names that are referenced by
+    the keyboard. The matching dispose call <a href="#km_kbp_keyboard_imx_list_dispose"><code class="token symbol">km_kbp_keyboard_imx_list_dispose</code></a>
+    needs to be called to free the memory.
+    </p>
+  </section>
+  <section class="specification">
+    <h2>Specification</h2>
+<pre><code class="language-c">km_kbp_status km_kbp_keyboard_get_imx_list(
+                              km_kbp_keyboard const *keyboard,
+                              km_kbp_keyboard_imx** imx_list);
+
+</code></pre>
+  </section>
+  <section class="parameters">
+    <h2>Parameters</h2>
+    <dl>
+      <dt id="keyboard"><code class="token symbol">keyboard</code></dt>
+      <dd>A pointer to the opaque keyboard object to be queried.</dd>
+
+      <dt id="imx_list"><code class="token symbol">imx_list</code></dt>
+      <dd>
+        A pointer to the result, an array of
+        <a href="#km_kbp_keyboard_imx"><code class="token symbol">km_kbp_keyboard_imx</code></a>
+        structure.
+      </dd>
+    </dl>
+  </section>
+  <section class="returns">
+    <h2>Returns</h2>
+    <dl>
+      <dt id="KM_KBP_STATUS_OK"><code class="token constant">KM_KBP_STATUS_OK</code></dt>
+      <dd>On success.</dd>
+
+      <dt id="KM_KBP_STATUS_INVALID_ARGUMENT"><code class="token constant">KM_KBP_STATUS_INVALID_ARGUMENT</code></dt>
+      <dd>If non-optional parameters are null.</dd>
+    </dl>
+  </section>
+</article>
+
+<article id="km_kbp_keyboard_imx_list_dispose">
+  <h1>km_kbp_keyboard_imx_list_dispose()</h1>
+  <section class="description">
+    <h2>Description</h2>
+    <p>
+    Free the allocated memory belonging to a IMX list previously
+returned by <a href="#km_kbp_keyboard_get_imx_list"><code class="token symbol">km_kbp_keyboard_get_imx_list</code></a>.
+    </p>
+  </section>
+  <section class="specification">
+    <h2>Specification</h2>
+<pre><code class="language-c">void km_kbp_keyboard_key_list_dispose(km_kbp_keyboard_key *key_list);
+
+</code></pre>
+  </section>
+  <section class="parameters">
+    <h2>Parameters</h2>
+    <dl>
+      <dt id="keyboard"><code class="token symbol">keyboard</code></dt>
+      <dd>A pointer to the IMX list to be
+    disposed of.</dd>
     </dl>
   </section>
 </article>

--- a/developer/core/desktop/16.0/c-api/keyboard-api.php
+++ b/developer/core/desktop/16.0/c-api/keyboard-api.php
@@ -16,7 +16,7 @@ head([
 
 
 <article id="km_kbp_keyboard_attrs">
-  <h1>km_kbp_keyboard_attrs</h1>
+  <h1>km_kbp_keyboard_attrs struct</h1>
   <section class="description">
     <h2>Description</h2>
     <p>A static structure describing the basic keyboard attributes.</p>
@@ -60,7 +60,7 @@ typedef struct {
 
 
 <article id="km_kbp_keyboard_load">
-  <h1>km_kbp_keyboard_load</h1>
+  <h1>km_kbp_keyboard_load()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -119,7 +119,7 @@ km_kbp_keyboard_load(km_kbp_path_name kb_path,
 
 
 <article id="km_kbp_keyboard_dispose">
-  <h1>km_kbp_keyboard_dispose</h1>
+  <h1>km_kbp_keyboard_dispose()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -145,7 +145,7 @@ km_kbp_keyboard_dispose(km_kbp_keyboard *keyboard);
 
 
 <article id="km_kbp_keyboard_get_attrs">
-  <h1>km_kbp_keyboard_get_attrs</h1>
+  <h1>km_kbp_keyboard_get_attrs()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>

--- a/developer/core/desktop/16.0/c-api/option-api.php
+++ b/developer/core/desktop/16.0/c-api/option-api.php
@@ -27,7 +27,7 @@ head([
 
 
 <article id="km_kbp_option_scope">
-  <h1>km_kbp_option_scope</h1>
+  <h1>km_kbp_option_scope enum</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -74,7 +74,7 @@ head([
 
 
 <article id="km_kbp_option_item">
-  <h1>km_kbp_option_item</h1>
+  <h1>km_kbp_option_item struct</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -121,7 +121,7 @@ head([
 
 
 <article id="KM_KBP_OPTIONS_END">
-  <h1>KM_KBP_OPTIONS_END</h1>
+  <h1>KM_KBP_OPTIONS_END macro</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -138,7 +138,7 @@ head([
 
 
 <article id="km_kbp_options_list_size">
-  <h1>km_kbp_options_list_size</h1>
+  <h1>km_kbp_options_list_size()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -177,7 +177,7 @@ km_kbp_options_list_size(km_kbp_option_item const *opts);
 
 
 <article id="km_kbp_state_option_lookup">
-  <h1>km_kbp_state_option_lookup</h1>
+  <h1>km_kbp_state_option_lookup()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -235,7 +235,7 @@ km_kbp_state_option_lookup(km_kbp_state const *state,
 
 
 <article id="km_kbp_state_options_update">
-  <h1>km_kbp_state_options_update</h1>
+  <h1>km_kbp_state_options_update()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -295,7 +295,7 @@ km_kbp_state_options_update(km_kbp_state *state,
 
 
 <article id="km_kbp_state_options_to_json">
-  <h1>km_kbp_state_options_to_json</h1>
+  <h1>km_kbp_state_options_to_json()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>

--- a/developer/core/desktop/16.0/c-api/state-api.php
+++ b/developer/core/desktop/16.0/c-api/state-api.php
@@ -14,7 +14,7 @@ head([
 
 
 <article id="km_kbp_action_item">
-  <h1>km_kbp_action_item</h1>
+  <h1>km_kbp_action_item struct</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -72,7 +72,7 @@ head([
 
 
 <article id="km_kbp_action_type">
-  <h1>km_kbp_action_type</h1>
+  <h1>km_kbp_action_type enum</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -135,7 +135,7 @@ enum km_kbp_action_type {
 
 
 <article id="km_kbp_state_create">
-  <h1>km_kbp_state_create</h1>
+  <h1>km_kbp_state_create()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -201,7 +201,7 @@ km_kbp_state_create(km_kbp_keyboard *keyboard,
 
 
 <article id="km_kbp_state_clone">
-  <h1>km_kbp_state_clone</h1>
+  <h1>km_kbp_state_clone()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>Clone an existing opaque state object.</p>
@@ -252,7 +252,7 @@ km_kbp_state_clone(km_kbp_state const *state,
 
 
 <article id="km_kbp_state_dispose">
-  <h1>km_kbp_state_dispose</h1>
+  <h1>km_kbp_state_dispose()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -284,7 +284,7 @@ km_kbp_state_dispose(km_kbp_state *state);
 
 
 <article id="km_kbp_state_context">
-  <h1>km_kbp_state_context</h1>
+  <h1>km_kbp_state_context()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>Get access to the state object's context.</p>
@@ -314,7 +314,7 @@ km_kbp_state_context(km_kbp_state *state);
 
 
 <article id="km_kbp_state_action_items">
-  <h1>km_kbp_state_action_items</h1>
+  <h1>km_kbp_state_action_items()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -368,7 +368,7 @@ km_kbp_state_context(km_kbp_state *state);
 
 
 <article id="km_kbp_state_to_json">
-  <h1>km_kbp_state_to_json</h1>
+  <h1>km_kbp_state_to_json()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -435,7 +435,7 @@ km_kbp_state_to_json(km_kbp_state const *state,
 
 
 <article id="km_kbp_process_event">
-  <h1>km_kbp_process_event</h1>
+  <h1>km_kbp_process_event()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -495,7 +495,7 @@ km_kbp_process_event(km_kbp_state *state,
 
 
 <article id="km_kbp_event">
-  <h1>km_kbp_event</h1>
+  <h1>km_kbp_event()</h1>
   <section class="description">
     <h2>Description</h2>
     <p>
@@ -549,7 +549,7 @@ km_kbp_event(km_kbp_state *state,
 
 
 <article id="km_kbp_event_code">
-  <h1>km_kbp_event_code</h1>
+  <h1>km_kbp_event_code enum</h1>
   <section class="description">
     <h2>Description</h2>
     <p>


### PR DESCRIPTION
Fixes #671.
Fixes #670.

And restores 15.0 Core API documentation missing in 16.0.