### PR TITLE
K8s convert pod to deployment

### DIFF
--- a/resources/kubectl/help-kubectl-deploy.yaml
+++ b/resources/kubectl/help-kubectl-deploy.yaml
@@ -17,7 +17,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    run: help-keyman-com
+    app: help-keyman-com
   name: help-keyman-com
   namespace: keyman
 spec:
@@ -30,7 +30,7 @@ spec:
     port: 9000
     protocol: TCP
   selector:
-    run: help-keyman-com
+    app: help-keyman-com
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/resources/kubectl/help-kubectl-dev.yaml
+++ b/resources/kubectl/help-kubectl-dev.yaml
@@ -44,5 +44,5 @@ spec:
     protocol: TCP
     nodePort: 30900
   selector:
-    run: help-keyman-com
+    app: help-keyman-com
 

--- a/resources/kubectl/help-kubectl.yaml
+++ b/resources/kubectl/help-kubectl.yaml
@@ -53,7 +53,7 @@ spec:
             port: 80
 
       - name: api
-        image: almir/webhook
+        image: alpine
         imagePullPolicy: IfNotPresent
         env:
         - name: DEPLOY_KEY
@@ -66,15 +66,15 @@ spec:
             configMapKeyRef:
               name: help-keyman-com
               key: site-branch
-        args:
-        - -verbose
-        - -urlprefix=api
-        - -template
-        - -hooks=/webhooks/hooks.yaml
-        lifecycle:
-          postStart:
-            exec:
-              command: ["/sbin/apk", "add", "git"]
+        command: ["sh", "-c"]
+        args: 
+        - |
+          set -e
+          apk add git webhook
+          exec webhook -verbose \
+            -urlprefix=api \
+            -template \
+            -hooks=/webhooks/hooks.yaml
         ports:
         - containerPort: 9000
         volumeMounts:
@@ -86,7 +86,7 @@ spec:
 
       initContainers:
       - name: init-site-data
-        image: bitnami/git
+        image: alpine
         imagePullPolicy: IfNotPresent
         env:
         - name: SITE_GIT_BRANCH
@@ -99,6 +99,8 @@ spec:
         - |
           test -d /mnt/.git && exit 0
           set -e
+          echo Install git
+          apk add git
           cd /mnt
           echo Initial clone
           git clone \

--- a/resources/kubectl/help-kubectl.yaml
+++ b/resources/kubectl/help-kubectl.yaml
@@ -94,6 +94,11 @@ spec:
             configMapKeyRef:
               name: help-keyman-com
               key: site-branch
+        - name: GIT_SPARSE_FILES
+          valueFrom:
+            configMapKeyRef:
+              name: help-keyman-com
+              key: git-sparse-checkout
         command: ["sh", "-c"]
         args:
         - |
@@ -112,15 +117,7 @@ spec:
           mv .toplevel/.git ./
           rmdir .toplevel
           echo Configure sparse-checkout
-          git sparse-checkout set --no-cone \
-            "/*"              \
-            "!.github"        \
-            "!resources"      \
-            "!.editorconfig"  \
-            "!composer.*"     \
-            "!Dockerfile"     \
-            "!Readme.md"      \
-            "!web.config"
+          echo "$GIT_SPARSE_FILES" | git sparse-checkout set --no-cone --stdin
           git checkout
           echo Link vendored PHP
           ln -sf /var/www/vendor vendor
@@ -149,6 +146,16 @@ metadata:
   namespace: keyman
 data:
   site-branch: staging
+  git-sparse-checkout: |
+    /*
+    !.editorconfig
+    !.github
+    !composer.*
+    !build.sh
+    !Dockerfile
+    !Readme.md
+    !resources
+    !web.config
   deployer: |
     #!/bin/sh
     git fetch && git reset --hard HEAD

--- a/resources/kubectl/help-kubectl.yaml
+++ b/resources/kubectl/help-kubectl.yaml
@@ -1,117 +1,144 @@
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: help-keyman-com
   namespace: keyman
   labels:
-    run: help-keyman-com
+    app: help-keyman-com
 spec:
-  terminationGracePeriodSeconds: 60
-  containers:
-  - name: app-php
-    image: docker.dallas.languagetechnology.org/keyman/help-keyman-app
-    imagePullPolicy: IfNotPresent
-    ports:
-    - containerPort: 80
-    volumeMounts:
-    - name: help-site-app
-      mountPath: /var/www/html
-    readinessProbe:
-      httpGet:
-        path: /robots.txt
-        port: 80
-      initialDelaySeconds: 5
-      periodSeconds: 15
-    livenessProbe:
-      tcpSocket:
-        port: 80
-
-  - name: api
-    image: almir/webhook
-    imagePullPolicy: IfNotPresent
-    env:
-    - name: DEPLOY_KEY
-      valueFrom:
-        secretKeyRef:
-          name: help-keyman-com
-          key: deploy_key
-    - name: SITE_GIT_BRANCH
-      valueFrom:
-        configMapKeyRef:
-          name: help-keyman-com
-          key: site-branch
-    args:
-    - -verbose
-    - -urlprefix=api
-    - -template
-    - -hooks=/webhooks/hooks.yaml
-    lifecycle:
-      postStart:
-        exec:
-          command: ["/sbin/apk", "add", "git"]
-    ports:
-    - containerPort: 9000
-    volumeMounts:
-    - name: webhooks
-      mountPath: /webhooks
-      readOnly: true
-    - name: help-site-app
-      mountPath: /mnt
-
-  initContainers:
-  - name: init-site-data
-    image: bitnami/git
-    imagePullPolicy: IfNotPresent
-    env:
-    - name: SITE_GIT_BRANCH
-      valueFrom:
-        configMapKeyRef:
-          name: help-keyman-com
-          key: site-branch
-    command: ["sh", "-c"]
-    args:
-    - |
-      test -d /mnt/.git && exit 0
-      set -e
-      cd /mnt
-      echo Initial clone
-      git clone \
-        --filter=blob:none \
-        --no-checkout \
-        --branch=${SITE_GIT_BRANCH} \
-        https://github.com/keymanapp/help.keyman.com.git \
-        .toplevel
-      mv .toplevel/.git ./
-      rmdir .toplevel
-      echo Configure sparse-checkout
-      git sparse-checkout set --no-cone \
-        "/*"              \
-        "!.github"        \
-        "!resources"      \
-        "!.editorconfig"  \
-        "!composer.*"     \
-        "!Dockerfile"     \
-        "!Readme.md"      \
-        "!web.config"
-      git checkout
-      echo Link vendored PHP
-      ln -sf /var/www/vendor vendor
-    volumeMounts:
-    - name: help-site-app
-      mountPath: /mnt
-  volumes:
-  - name: help-site-app
-    persistentVolumeClaim:
-      claimName: help-keyman-com
-  - name: webhooks
-    configMap:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: help-keyman-com
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: help-keyman-com
       name: help-keyman-com
-      items:
-      - key: deployer
-        path: deploy.sh
-        mode: 0555
-      - key: webhooks
-        path: hooks.yaml
+      namespace: keyman
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - help-keyman-com
+            topologyKey: kubernetes.io/hostname
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: app-php
+        image: docker.dallas.languagetechnology.org/keyman/help-keyman-app
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: help-site-app
+          mountPath: /var/www/html
+        readinessProbe:
+          httpGet:
+            path: /robots.txt
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 15
+        livenessProbe:
+          tcpSocket:
+            port: 80
+
+      - name: api
+        image: almir/webhook
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: DEPLOY_KEY
+          valueFrom:
+            secretKeyRef:
+              name: help-keyman-com
+              key: deploy_key
+        - name: SITE_GIT_BRANCH
+          valueFrom:
+            configMapKeyRef:
+              name: help-keyman-com
+              key: site-branch
+        args:
+        - -verbose
+        - -urlprefix=api
+        - -template
+        - -hooks=/webhooks/hooks.yaml
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/sbin/apk", "add", "git"]
+        ports:
+        - containerPort: 9000
+        volumeMounts:
+        - name: webhooks
+          mountPath: /webhooks
+          readOnly: true
+        - name: help-site-app
+          mountPath: /mnt
+
+      initContainers:
+      - name: init-site-data
+        image: bitnami/git
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: SITE_GIT_BRANCH
+          valueFrom:
+            configMapKeyRef:
+              name: help-keyman-com
+              key: site-branch
+        command: ["sh", "-c"]
+        args:
+        - |
+          test -d /mnt/.git && exit 0
+          set -e
+          cd /mnt
+          echo Initial clone
+          git clone \
+            --filter=blob:none \
+            --no-checkout \
+            --branch=${SITE_GIT_BRANCH} \
+            https://github.com/keymanapp/help.keyman.com.git \
+            .toplevel
+          mv .toplevel/.git ./
+          rmdir .toplevel
+          echo Configure sparse-checkout
+          git sparse-checkout set --no-cone \
+            "/*"              \
+            "!.github"        \
+            "!resources"      \
+            "!.editorconfig"  \
+            "!composer.*"     \
+            "!Dockerfile"     \
+            "!Readme.md"      \
+            "!web.config"
+          git checkout
+          echo Link vendored PHP
+          ln -sf /var/www/vendor vendor
+        volumeMounts:
+        - name: help-site-app
+          mountPath: /mnt
+
+      volumes:
+      - name: help-site-app
+        persistentVolumeClaim:
+          claimName: help-keyman-com
+      - name: webhooks
+        configMap:
+          name: help-keyman-com
+          items:
+          - key: deployer
+            path: deploy.sh
+            mode: 365
+          - key: webhooks
+            path: hooks.yaml
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
We want this so a k8s cluster can automatically migrate a workload to another node, perform rolling upgrades and scale instances up or down. A bare pod is not really the right way to deploy outside prototyping.
Also
1. Reduce the number images we depend on for sidecar/init containers to just alpine, for a smaller foot print and smaller supply chain attack surface.
2. Move specification of which files in the repo to include/exclude in the document root out of the init container shell script and into a ConfigMap entry for easier maintenance and clarity.