### PR TITLE
Remove dev requirement for Composer [Take 2]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         fail-fast: true
 
     #
-    # Install website PHP dependencies (copies vendor/ to the proper folder)
+    # Create link to vendor/ dependencies
     #
     - name:  Install dependencies
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,23 +22,22 @@ jobs:
       env:
         fail-fast: true
 
+    - name: Build the Docker image
+      shell: bash
+      # --mount option requires BuildKit
+      run: |
+        ./build.sh build start
+      env:
+        fail-fast: true
+
     #
-    # Install website PHP dependencies
+    # Install website PHP dependencies (copies vendor/ to the proper folder)
     #
     - name:  Install dependencies
       shell: bash
       run: |
         echo "TIER_TEST" > tier.txt
         ./build.sh configure
-        # composer install --no-progress
-      env:
-        fail-fast: true
-
-    - name: Build the Docker image
-      shell: bash
-      # --mount option requires BuildKit
-      run: |
-        ./build.sh build start
       env:
         fail-fast: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 **/.DS_Store
 .idea/
 cdn/deploy
-vendor/
+vendor*
 .vscode/
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,28 @@
 # syntax=docker/dockerfile:1
-FROM php:7.4-apache AS builder
+FROM php:7.4-apache AS composer-builder
+
+# Install Zip to use composer
+RUN apt-get update && apt-get install -y \
+    zlib1g-dev \
+    libzip-dev \
+    unzip
+RUN docker-php-ext-install zip
+
+# Install and update composer
 COPY --from=composer /usr/bin/composer /usr/bin/composer
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/var/lib/apt,sharing=private \
-  apt-get update && apt-get install -y unzip
+RUN composer self-update
+
 USER www-data
-WORKDIR /var/www/html
-COPY composer.* ./
+WORKDIR /composer
+COPY composer.* /composer/
 RUN composer install
 
+# Site
 FROM php:7.4-apache
 COPY resources/keyman-site.conf /etc/apache2/conf-available/
-COPY --chown=www-data --from=builder /var/www/html/vendor /var/www/vendor
+RUN chown -R www-data:www-data /var/www/html/
+
+COPY --from=composer-builder /composer/vendor /var/www/vendor
 RUN a2enmod rewrite; a2enconf keyman-site
+
+# build.sh configure later needed to COPY /var/www/vendor to /var/www/html/vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ RUN chown -R www-data:www-data /var/www/html/
 COPY --from=composer-builder /composer/vendor /var/www/vendor
 RUN a2enmod rewrite; a2enconf keyman-site
 
-# build.sh configure later needed to COPY /var/www/vendor to /var/www/html/vendor
+# build.sh configure later needed to create link to vendor/

--- a/Readme.md
+++ b/Readme.md
@@ -15,10 +15,6 @@ On Windows, Docker will also need either:
 
 ### Builder actions
 
-#### Configure
-Install PHP dependencies in vendor/ folder
-1. Run `./build.sh configure`.
-
 #### Stop the Docker container
 1. Run `./build.sh stop`
 
@@ -27,6 +23,10 @@ Install PHP dependencies in vendor/ folder
 
 #### Start the Docker container
 1. Run `./build.sh start`.
+
+#### Configure
+Move PHP dependencies in Docker image from /var/www/vendor/ to /var/www/html/vendor
+1. Run `./build.sh configure`.
 
 After this, you can access the help.keyman site at http://localhost:8055
 

--- a/build.sh
+++ b/build.sh
@@ -44,8 +44,21 @@ builder_parse "$@"
 cd "$REPO_ROOT"
 
 if builder_start_action configure; then
-  composer install
-  
+  # Remove local vendor/ dir if it already exists
+  pwd
+  if [ -d "vendor/" ]; then
+    echo "Removing existing vendor/ folder"
+    rm -rf vendor/
+  fi
+
+  # Move PHP depdendencies in vendor/
+  # This takes a while cause it also syncs to host
+  HELP_CONTAINER=$(_get_docker_container_id)
+  if [ ! -z "$HELP_CONTAINER" ]; then
+    docker exec -i $HELP_CONTAINER sh -c "cp -r /var/www/vendor /var/www/html/"
+  else
+    echo "No Docker container to configure"
+  fi
   builder_finish_action success configure
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -44,18 +44,10 @@ builder_parse "$@"
 cd "$REPO_ROOT"
 
 if builder_start_action configure; then
-  # Remove local vendor/ dir if it already exists
-  pwd
-  if [ -d "vendor/" ]; then
-    echo "Removing existing vendor/ folder"
-    rm -rf vendor/
-  fi
-
-  # Move PHP depdendencies in vendor/
-  # This takes a while cause it also syncs to host
+  # Create link to vendor/ folder
   HELP_CONTAINER=$(_get_docker_container_id)
   if [ ! -z "$HELP_CONTAINER" ]; then
-    docker exec -i $HELP_CONTAINER sh -c "cp -r /var/www/vendor /var/www/html/"
+    docker exec -i $HELP_CONTAINER sh -c "ln -s /var/www/vendor vendor"
   else
     echo "No Docker container to configure"
   fi

--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ if builder_start_action configure; then
     # Create link to vendor/ folder
     HELP_CONTAINER=$(_get_docker_container_id)
     if [ ! -z "$HELP_CONTAINER" ]; then
-      docker exec -i $HELP_CONTAINER sh -c "ln -s /var/www/vendor vendor"
+      docker exec -i $HELP_CONTAINER sh -c "ln -s /var/www/vendor vendor && chown -R www-data:www-data vendor"
     else
       echo "No Docker container to configure"
     fi

--- a/build.sh
+++ b/build.sh
@@ -44,12 +44,17 @@ builder_parse "$@"
 cd "$REPO_ROOT"
 
 if builder_start_action configure; then
-  # Create link to vendor/ folder
-  HELP_CONTAINER=$(_get_docker_container_id)
-  if [ ! -z "$HELP_CONTAINER" ]; then
-    docker exec -i $HELP_CONTAINER sh -c "ln -s /var/www/vendor vendor"
+  # Skip if link already exists
+  if [ -L vendor ]; then
+    echo "Skipping because vendor already exists"
   else
-    echo "No Docker container to configure"
+    # Create link to vendor/ folder
+    HELP_CONTAINER=$(_get_docker_container_id)
+    if [ ! -z "$HELP_CONTAINER" ]; then
+      docker exec -i $HELP_CONTAINER sh -c "ln -s /var/www/vendor vendor"
+    else
+      echo "No Docker container to configure"
+    fi
   fi
   builder_finish_action success configure
 fi


### PR DESCRIPTION
Replaces #675

This is a second attempt to fix #674 and have the Docker file handle `composer install` so the dev environment doesn't need to have Composer installed.
Because of the way Docker handles filesystems, I had to move `build.sh configure` to link the `vendor/` folder after the container is running.

Previous attempts to copy `vendor/` to `/var/www/html/` don't work because the when the container starts, it replaces the folder with what's on the host (which doesn't have a `vendor/` folder)

Updates inspired from 
* [medium.com post](https://medium.com/@lukaspereyra8/docker-compose-php-composer-the-missing-vendors-folder-issue-66faa5475c59)
* [web-languageforge](https://github.com/sillsdev/web-languageforge/blob/ba4bf1ae838e48b4f2c2d7fa9861a7727eb04362/docker/app/Dockerfile#L38-L47)

## Steps for Developer
```bash
# Build the docker image and start the container
./build.sh build start 

# Link the vendor/ dependencies
./build.sh configure

# site now accessible at http://localhost:8055
```