### PR TITLE
fix: Move link of vendor/ from build.sh configure to start 🦭

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,22 +22,13 @@ jobs:
       env:
         fail-fast: true
 
+    # Build the docker image and create link to vendor/ dependencies
     - name: Build the Docker image
       shell: bash
       # --mount option requires BuildKit
       run: |
         ./build.sh build start
-      env:
-        fail-fast: true
-
-    #
-    # Create link to vendor/ dependencies
-    #
-    - name:  Install dependencies
-      shell: bash
-      run: |
         echo "TIER_TEST" > tier.txt
-        ./build.sh configure
       env:
         fail-fast: true
 

--- a/build.sh
+++ b/build.sh
@@ -44,18 +44,7 @@ builder_parse "$@"
 cd "$REPO_ROOT"
 
 if builder_start_action configure; then
-  # Skip if link already exists
-  if [ -L vendor ]; then
-    echo "Skipping because vendor already exists"
-  else
-    # Create link to vendor/ folder
-    HELP_CONTAINER=$(_get_docker_container_id)
-    if [ ! -z "$HELP_CONTAINER" ]; then
-      docker exec -i $HELP_CONTAINER sh -c "ln -s /var/www/vendor vendor && chown -R www-data:www-data vendor"
-    else
-      echo "No Docker container to configure"
-    fi
-  fi
+  # Nothing to do
   builder_finish_action success configure
 fi
 
@@ -105,6 +94,19 @@ if builder_start_action start; then
   else
     echo "${COLOR_RED}ERROR: Docker container doesn't exist. Run ./build.sh build first${COLOR_RESET}"
     builder_finish_action fail start
+  fi
+
+  # Skip if link already exists
+  if [ -L vendor ]; then
+    echo "Link to vendor/ already exists"
+  else
+    # Create link to vendor/ folder
+    HELP_CONTAINER=$(_get_docker_container_id)
+    if [ ! -z "$HELP_CONTAINER" ]; then
+      docker exec -i $HELP_CONTAINER sh -c "ln -s /var/www/vendor vendor && chown -R www-data:www-data vendor"
+    else
+      echo "No Docker container not running to create link to vendor/"
+    fi
   fi
 
   builder_finish_action success start


### PR DESCRIPTION
Follow-on to #681 
@mcdurdin pointed out `./build.sh configure` should occur before `./build.sh start`.

So this moves the link step from `configure` to the end of `start`.
This way Docker maps the local folder first, and creating the link to vendor/ stays.

Will propagate this change to other websites and update keymanapp/keyman#8034