### PR TITLE
chore: Update current-version to 16.0

### DIFF
--- a/web.config
+++ b/web.config
@@ -45,7 +45,15 @@
                     <action type="Rewrite" url="{R:1}/XX.0{R:2}" />
                 </rule>-->
 
-                <rule name="current-version:15.0">
+                <rule name="current-version:16.0">
+                    <match url="^(.+)/current-version(/.*|$)" />
+                    <conditions>
+                        <add matchType="IsDirectory" input="{DOCUMENT_ROOT}/{R:1}/16.0" />
+                    </conditions>
+                    <action type="Rewrite" url="{R:1}/16.0{R:2}" />
+                </rule>
+
+                <rule name="version:15.0">
                     <match url="^(.+)/current-version(/.*|$)" />
                     <conditions>
                         <add matchType="IsDirectory" input="{DOCUMENT_ROOT}/{R:1}/15.0" />


### PR DESCRIPTION
@jahorton noticed https://help.keyman.com/DEVELOPER/ENGINE/WEB/current-version/ was still going to 15.0 content.

Now that 16.0 is released, this updates `current-version` from 15.0 to 16.0.

Note: staging branch will need the corresponding change in `.htaccess`

