### PR TITLE
cask is now option, not command

### DIFF
--- a/knowledge-base/kb0095.md
+++ b/knowledge-base/kb0095.md
@@ -8,8 +8,8 @@ KMComp is the command line compiler included in Keyman Developer. It is a window
 If you do not have `wine` already installed, install `wine` using [Homebrew](https://brew.sh/):
 
 ```sh
-$ brew cask install xquartz
-$ brew cask install wine-stable
+$ brew install --cask xquartz
+$ brew install --cask wine-stable
 ```
 
 See:


### PR DESCRIPTION
When I tried to use cask as a command like this used to direct us to, I got the message:
    Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.