### PR TITLE
chore: Update references to kmw in examples

### DIFF
--- a/developer/engine/web/17.0/guide/adding-keyboards.php
+++ b/developer/engine/web/17.0/guide/adding-keyboards.php
@@ -25,7 +25,7 @@ head([
   Once this is done, it can be directly linked into KeymanWeb as follows.</p>
 
 <pre><code>
-kmw.addKeyboards({
+keyman.addKeyboards({
     id:'us',                  // The keyboard's unique identification code.
     name:'English',           // The keyboard's user-readable name.
     language:{
@@ -49,13 +49,13 @@ font:{
 
 <p>To obtain the default Keyman keyboard for a given language, call the following function.</p>
 
-<pre><code>kmw.addKeyboardsForLanguage('Dzongkha');</code></pre>
+<pre><code>keyman.addKeyboardsForLanguage('Dzongkha');</code></pre>
 
 <p>This example would find the default keyboard for the Dzongkha language.  This method will fail if the name doesn't perfectly match any language found in the CDN's repository.</p>
 
 <p>Alternatively, languages may be looked up via their BCP 47 language code as follows:</p>
 
-<pre><code>kmw.addKeyboards('@he')</code></pre>
+<pre><code>keyman.addKeyboards('@he')</code></pre>
 
 <p>The <code>@</code> prefix indicates the use of the BCP 47 language code, which in this case corresponds with Hebrew.</p>
 
@@ -63,6 +63,6 @@ font:{
 
 <p>To obtain a specific keyboard by name or by keyboard name and language code as a pair, see the following:</p>
 
-<pre><code>kmw.addKeyboards('french','european2@sv','european2@no')</code></pre>
+<pre><code>keyman.addKeyboards('french','european2@sv','european2@no')</code></pre>
 
 <p>This will install three keyboards - one for French (named, quite simply, "French") and two copies of the EuroLatin2 keyboard - one for Swedish and one for Norwegian.</p>

--- a/developer/engine/web/17.0/guide/examples/__auto-control.php
+++ b/developer/engine/web/17.0/guide/examples/__auto-control.php
@@ -7,8 +7,8 @@
 
   <script>
     window.addEventListener('load', function () {
-      kmw.init().then(function() {
-        kmw.addKeyboards({
+      keyman.init().then(function() {
+        keyman.addKeyboards({
           id:'laokeys',
           name:'Lao (Phonetic)',
           languages:{

--- a/developer/engine/web/17.0/guide/examples/__control-by-control.php
+++ b/developer/engine/web/17.0/guide/examples/__control-by-control.php
@@ -21,7 +21,7 @@ if(isset($debug) && isset($dev_path)) {
 
 <script type="text/javascript">
   function SetupDocument() {
-    kmw.init({
+    keyman.init({
       root: './',  // Note - if drawing the latest version of KeymanWeb from the CDN, this will
                    // default to the source folder on our servers.
       ui: 'toggle',
@@ -31,13 +31,13 @@ if(isset($debug) && isset($dev_path)) {
       loadKeyboards();
 
       /* Disable KeymanWeb interaction on the 'Email to' TEXT control */
-      kmw.disableControl(document.f.address);
+      keyman.disableControl(document.f.address);
       /* Set the default keyboard for the 'Subject' TEXT control to 'off' (i.e. default browser keyboard) */
       /* As KeymanWeb relies on the on-screen keyboard to change languages for touch-based devices, this will
        * not work for them and will default to the first language added to KeymanWeb after initialization. */
-      kmw.setKeyboardForControl(document.f.subject, '', '');
+      keyman.setKeyboardForControl(document.f.subject, '', '');
       /* Set the default keyboard for the 'Message body' TEXTAREA to the LaoKeys keyboard */
-      kmw.setKeyboardForControl(document.f.text, 'Keyboard_laokeys', 'lo');
+      keyman.setKeyboardForControl(document.f.text, 'Keyboard_laokeys', 'lo');
     });
   }
 

--- a/developer/engine/web/17.0/guide/examples/__first-example.php
+++ b/developer/engine/web/17.0/guide/examples/__first-example.php
@@ -13,10 +13,10 @@
   ?>
   <script src='<?=$cdn_path?>/kmwuitoggle.js'></script>
   <script>
-    (function(kmw) {
-      kmw.init({attachType:'auto'}).then(function() {
-        kmw.addKeyboards('@en'); // Loads default English keyboard from Keyman Cloud (CDN)
-        kmw.addKeyboards('@th'); // Loads default Thai keyboard from Keyman Cloud (CDN)
+    (function() {
+      keyman.init({attachType:'auto'}).then(function() {
+        keyman.addKeyboards('@en'); // Loads default English keyboard from Keyman Cloud (CDN)
+        keyman.addKeyboards('@th'); // Loads default Thai keyboard from Keyman Cloud (CDN)
       });
     })(keyman);
   </script>

--- a/developer/engine/web/17.0/guide/examples/__full-manual-control.php
+++ b/developer/engine/web/17.0/guide/examples/__full-manual-control.php
@@ -13,12 +13,12 @@ var KWControl = null;
 
 function SetupDocument()
 {
-  kmw.init().then(function(){
+  keyman.init().then(function(){
     // Load the keyboards of your choice here.
     loadKeyboards();
 
     KWControl = document.getElementById('KWControl');
-    var kbds = kmw.getKeyboards();
+    var kbds = keyman.getKeyboards();
     for(var kbd in kbds)
     {
       var opt = document.createElement('OPTION');
@@ -28,7 +28,7 @@ function SetupDocument()
     }
     document.f.multilingual.focus();
 
-    kmw.setActiveKeyboard('', '');
+    keyman.setActiveKeyboard('', '');
   });
 }
 
@@ -36,7 +36,7 @@ function KWControlChange()
 {
   var name = KWControl.value.substr(0, KWControl.value.indexOf("$$"));
   var languageCode = KWControl.value.substr(KWControl.value.indexOf("$$") + 2);
-  kmw.setActiveKeyboard(name, languageCode);
+  keyman.setActiveKeyboard(name, languageCode);
   document.f.multilingual.focus();
 }
 

--- a/developer/engine/web/17.0/guide/examples/__manual-control.php
+++ b/developer/engine/web/17.0/guide/examples/__manual-control.php
@@ -9,28 +9,28 @@
 
   <script type="text/javascript">
 
-      var KWControl = null;
+    var KWControl = null;
 
-      function SetupDocument()
-      {
-          kmw.init();
-          KWControl = document.getElementById('KWControl');
-          kmw.setActiveKeyboard('laokeys');
-          kmw.osk.hide();
+    function SetupDocument()
+    {
+      keyman.init();
+      KWControl = document.getElementById('KWControl');
+      keyman.setActiveKeyboard('laokeys');
+      keyman.osk.hide();
+    }
+
+    function KWControlClick()
+    {
+      var KWControl = document.getElementById('KWControl');
+
+      if(keyman.osk.isEnabled()) {
+        keyman.osk.hide();
+      } else {
+        keyman.osk.show(true); // Specifies that the OSK should display whenever a valid control has focus, re-enabling the default behavior.
       }
+    }
 
-      function KWControlClick()
-      {
-          var KWControl = document.getElementById('KWControl');
-
-          if(kmw.osk.isEnabled()) {
-              kmw.osk.hide();
-          } else {
-              kmw.osk.show(true); // Specifies that the OSK should display whenever a valid control has focus, re-enabling the default behavior.
-          }
-      }
-
-      window.addEventListener('load', SetupDocument);
+    window.addEventListener('load', SetupDocument);
   </script>
 </head>
 <body>

--- a/developer/engine/web/17.0/guide/get-started.php
+++ b/developer/engine/web/17.0/guide/get-started.php
@@ -47,10 +47,10 @@ echo codebox(<<<END
   <script src='$cdn_path/keymanweb.js'></script>
   <script src='$cdn_path/kmwuitoggle.js'></script>
   <script>
-    (function(kmw) {
-      kmw.init({attachType:'auto'}).then(function() {
-        kmw.addKeyboards('@eng'); // Loads default English keyboard from Keyman Cloud (CDN)
-        kmw.addKeyboards('@tha'); // Loads default Thai keyboard from Keyman Cloud (CDN)
+    (function() {
+      keyman.init({attachType:'auto'}).then(function() {
+        keyman.addKeyboards('@eng'); // Loads default English keyboard from Keyman Cloud (CDN)
+        keyman.addKeyboards('@tha'); // Loads default Thai keyboard from Keyman Cloud (CDN)
       });
     })(keyman);
   </script>
@@ -71,8 +71,8 @@ END
 <li><p>The <code>&lt;script&gt;</code> inclusion <code>&lt;script src='<?=$cdn_path?>/keymanweb.js'&gt;&lt;/script&gt;</code>
     loads the Keyman Engine for Web script for the page.</p></li>
 
-<li><p><code>(function(kmw) { kmw.init(); });</code> serves to initialize the web engine with default settings.
-  By adding the object <code>{attachType:'auto'}</code> as a parameter to our <code>kmw.init()</code> call, the
+<li><p><code>(function() { keyman.init(); });</code> serves to initialize the web engine with default settings.
+  By adding the object <code>{attachType:'auto'}</code> as a parameter to our <code>keyman.init()</code> call, the
     KeymanWeb engine will then link into any detected input elements automatically, regardless of browser or device, as part
     of its initialization.</p></li>
 
@@ -80,7 +80,7 @@ END
       creates the language menu seen on non-mobile devices and the on-screen keyboard toggle button.
       For other options, see our <a href='user-interface-design.php'>User Interface Design</a> page.</p></li>
 
-  <li><p>The calls to <code>kmw.addKeyboards()</code> in the source above link in the two example Keyman keyboards used
+  <li><p>The calls to <code>keyman.addKeyboards()</code> in the source above link in the two example Keyman keyboards used
       in this demo from our CDN server.  For more info on how to include keyboards in your KeymanWeb installation, check
       the <a href='adding-keyboards.php'>Adding Keyboards</a> page.</p></li>
 


### PR DESCRIPTION
Follow-on to #710 

Updates more references from `kmw` to `keyman` in the 17.0 code examples.
