### PR TITLE
chore: Update GHA to use node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.5.2
 
     - name: Setup PHP 7.4
       uses: shivammathur/setup-php@6972aed899fa2dd4016a7e314c46e6902bcafb7b


### PR DESCRIPTION
Fixes #711 

TODO: deprecated npm packages