### PR TITLE
chore: fix broken links in gff help

### DIFF
--- a/keyboard/gff_harari/1.0.1/gff_harari.php
+++ b/keyboard/gff_harari/1.0.1/gff_harari.php
@@ -1,8 +1,8 @@
 ﻿<?php /*
   Name:             Keyboard_gff_harari
-  Copyright:        Keyboard ©2023 The Geʾez Frontier Foundation 
-  Documentation:    
-  Description:      
+  Copyright:        Keyboard ©2023 The Geʾez Frontier Foundation
+  Documentation:
+  Description:
   Create Date:      17 April 2023
 
 */
@@ -174,7 +174,7 @@ This keyboard is designed for use with the Harari language of Ethiopia in Africa
 
 <div id="Documentation">
 <h3>Keyboard Details</h3>
-	
+
 <p>
 The Harari keyboard uses an intuitive <i>phonetic</i> system where the Harari sounds are matched to the nearest English letters. You can think of how a word sounds in
 Harari and then type it out with English.
@@ -202,11 +202,10 @@ Type Apostrophe twice after a 6<sup>th</sup> order letter to make it appear in y
 <p style='margin-left:40px'><b>Example:</b> typing <span class='keys'>mel''ak</span> produces <span class='highlightExample'>መል'አክ</span></p>
 <p>
 We also use the &ldquo;number sign&rdquo; (&ldquo;#&rdquo; also know as the &ldquo;hash mark&rdquo;) for Ethiopic numbers, so <span class='keys'>#1</span> becomes <span class='highlightExample'>፩</span> and so on. If a <span class='highlightExample'>#</span> is needed in your document before a number, type it twice and: <span class='keys'>##1</span> becomes <span class='highlight'>#1</span>. The double strike works for other punctuation as well,
-so typing <span class='keys'>;</span> once makes <span class='highlightExample'>፤</span> and a second time gives English semicolon <span class='input'>;</span>. 
+so typing <span class='keys'>;</span> once makes <span class='highlightExample'>፤</span> and a second time gives English semicolon <span class='input'>;</span>.
 </p>
 <p style='margin-top:10px'>
-See <a target="_blank" href='HarariTyping-English.pdf'>Typing in Harari (English)</a> or 
-<a target="_blank" href='HarariTyping-Harari.pdf'>Typing in Harari (Harari)</a> 
+See <a target="_blank" href='HarariTyping-English.pdf'>Typing in Harari (English)</a>
 for full details on how to type all Harari letters, numbers and punctuation.
 </p>
 </div>

--- a/keyboard/gff_tigre/1.0/gff_tigre.php
+++ b/keyboard/gff_tigre/1.0/gff_tigre.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
   $pagename = "GFF Tigre";
   $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Tigre";
   $pagestyle = <<<END
@@ -72,16 +72,16 @@ END;
 <h2><a id="abstract" name="abstract"></a>Introduction</h2>
 
 <p style="text-align: justify;">
-This is a Tigre (tig, ትግሬ, ትግረ) language mnemonic input method that applies Eritrean writing conventions. 
-It requires a font supporting Ethiopic script under the Unicode 3.0 standard. 
+This is a Tigre (tig, ትግሬ, ትግረ) language mnemonic input method that applies Eritrean writing conventions.
+It requires a font supporting Ethiopic script under the Unicode 3.0 standard.
 The Tigre keyboard is &ldquo;mnemonic&rdquo; and designed for the US English QWERTY keyboard.  This means that the keyboard is designed to
 be intuitive and natural with respect to the sounds available in the English language via the standard English keyboard (known as QWERTY).
 The keyboard also supports mnemonic mappings from non-English letters found in European keyboards.
 </p>
 
-<p>A more complete typing manual is <a target="_blank" href="TigreTyping.pdf">provided as a PDF file</a> with this distribution.</p>
+<p>A more complete typing manual is <a target="_blank" href="TigreTyping-English.pdf">provided as a PDF file</a> with this distribution.</p>
 </div>
- 
+
 <h2><a id="status" name="status"></a>Typing Letter</h2>
 
 <p style="text-align: justify;">

--- a/keyboard/gff_tigrinya_eritrea/2.0/gff_tigrinya_eritrea.php
+++ b/keyboard/gff_tigrinya_eritrea/2.0/gff_tigrinya_eritrea.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
   $pagename = "GFF Eritrean Tigrinya";
   $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Eritrean Tigrinya";
   $pagestyle = <<<END
@@ -72,16 +72,16 @@ END;
 <h2><a id="abstract" name="abstract"></a>Introduction</h2>
 
 <p style="text-align: justify;">
-This is a Tigrinya (ti-ER, ትግርኛ-ኤርትራ) language mnemonic input method that applies Eritrean writing conventions. 
-It requires a font supporting Ethiopic script under the Unicode 3.0 standard. 
+This is a Tigrinya (ti-ER, ትግርኛ-ኤርትራ) language mnemonic input method that applies Eritrean writing conventions.
+It requires a font supporting Ethiopic script under the Unicode 3.0 standard.
 The Tigrinya keyboard is &ldquo;mnemonic&rdquo; and designed for the US English QWERTY keyboard.  This means that the keyboard is designed to
 be intuitive and natural with respect to the sounds available in the English language via the standard English keyboard (known as QWERTY).
 The keyboard also supports mnemonic mappings from non-English letters found in European keyboards.
 </p>
 
-<p>A more complete typing manual is <a target="_blank" href="TigrinyaErTyping.pdf">provided as a PDF file</a> with this distribution.</p>
+<p>A more complete typing manual is <a target="_blank" href="TigrinyaErTyping-English.pdf">provided as a PDF file</a> with this distribution.</p>
 </div>
- 
+
 <h2><a id="status" name="status"></a>Typing Letter</h2>
 
 <p style="text-align: justify;">


### PR DESCRIPTION
Fixes #729.

Note that gff_tigre and gff_tigrinya_eritrea will be overwritten by next keyboards deploy (gff_harari is now on 1.0.2 so 1.0.1 will never be rewritten by keyboards deploy again). So see keymanapp/keyboards#2255 for permafix for those two keyboards.

Am applying the fix here anyway so we can get green lights on CI, making sure nothing else is wrong.