### PR TITLE
fix: Use .localhost instead of .local 🦭

### DIFF
--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -119,7 +119,7 @@
         $this->r_keymanweb_com = "https://r.keymanweb.com";
       } else if($this->tier == KeymanHosts::TIER_DEVELOPMENT) {
         // Locally running sites via Docker need to access "host.docker.internal:[port]"
-        $this->s_keyman_com = "{$site_protocol}s.keyman.com{$site_suffix}";
+        $this->s_keyman_com = "http://host.docker.internal:8054";
         $this->api_keyman_com = "http://host.docker.internal:8098";
         $this->help_keyman_com = "http://host.docker.internal:8055";
         $this->downloads_keyman_com = "https://downloads.keyman.com"; // local dev domain is usually not available

--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -5,7 +5,7 @@
 
   class KeymanHosts {
     // Four tiers. These use the following rough patterns:
-    // * development = [x.]keyman.com.local
+    // * development = [x.]keyman.com.localhost
     // * Staging = [x.]keyman-staging.com
     // * Production = [x.]keyman.com
     // * Test = GitHub actions, localhost:8888 (uses staging tier for other hosts)
@@ -87,8 +87,8 @@
         $site_protocol = 'http://';
         break;
       case KeymanHosts::TIER_DEVELOPMENT:
-        $site_suffix = '.local';
-        $site_protocol = 'https://';
+        $site_suffix = '.localhost';
+        $site_protocol = 'http://';
         break;
       default:
         die("tier is '$this->tier' which is invalid\n");
@@ -99,7 +99,7 @@
       $this->translate_keyman_com = "https://translate.keyman.com";
       $this->sentry_keyman_com = "https://sentry.keyman.com";
 
-      if(in_array($this->tier, [KeymanHosts::TIER_STAGING, KeymanHosts::TIER_TEST])) {
+      if($this->tier == KeymanHosts::TIER_STAGING) {
         // As we build more staging areas, change these over as well. Assumption that we'll stage across multiple sites is a
         // little presumptuous but we can live with it.
         $this->s_keyman_com = "https://s.keyman.com";
@@ -109,12 +109,29 @@
         $this->keyman_com = "https://keyman-staging.com";
         $this->keymanweb_com = "https://keymanweb.com";
         $this->r_keymanweb_com = "https://r.keymanweb.com";
+      } else if($this->tier == KeymanHosts::TIER_TEST) {
+        $this->s_keyman_com = "https://s.keyman.com";
+        $this->api_keyman_com = "https://api.keyman.com";
+        $this->help_keyman_com = "https://help.keyman.com";
+        $this->downloads_keyman_com = "https://downloads.keyman.com";
+        $this->keyman_com = "https://keyman.com";
+        $this->keymanweb_com = "https://keymanweb.com";
+        $this->r_keymanweb_com = "https://r.keymanweb.com";
+      } else if($this->tier == KeymanHosts::TIER_DEVELOPMENT) {
+        // Locally running sites via Docker need to access "host.docker.internal:[port]"
+        $this->s_keyman_com = "{$site_protocol}s.keyman.com{$site_suffix}";
+        $this->api_keyman_com = "http://host.docker.internal:8098";
+        $this->help_keyman_com = "http://host.docker.internal:8055";
+        $this->downloads_keyman_com = "https://downloads.keyman.com"; // local dev domain is usually not available
+        $this->keyman_com = "http://host.docker.internal:8053";
+        $this->keymanweb_com = "http://host.docker.internal:8057";
+        $this->r_keymanweb_com = "https://r.keymanweb.com"; /// local dev domain is usually not available
       } else {
         // TODO: allow override of these with e.g. KEYMANHOSTS_API_KEYMAN_COM='https://api.keyman.com';
         $this->s_keyman_com = "{$site_protocol}s.keyman.com{$site_suffix}";
         $this->api_keyman_com = "{$site_protocol}api.keyman.com{$site_suffix}";
         $this->help_keyman_com = "{$site_protocol}help.keyman.com{$site_suffix}";
-        $this->downloads_keyman_com = "{$site_protocol}downloads.keyman.com{$site_suffix}";
+        $this->downloads_keyman_com = "https://downloads.keyman.com"; // local dev domain is usually not available
         $this->keyman_com = "{$site_protocol}keyman.com{$site_suffix}";
         $this->keymanweb_com = "{$site_protocol}keymanweb.com{$site_suffix}";
         $this->r_keymanweb_com = "https://r.keymanweb.com"; /// local dev domain is usually not available


### PR DESCRIPTION
This follows the sites-wide direction to use .localhost instead of .local for local Dev-hosted sites.
Mirrors keymanapp/keyman.com@3c9abe14fbb49d19bd3082081cfaf3ecf00cd82b