### PR TITLE
chore: Move api.keyman.com.localhost to port 8058

### DIFF
--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -120,7 +120,7 @@
       } else if($this->tier == KeymanHosts::TIER_DEVELOPMENT) {
         // Locally running sites via Docker need to access "host.docker.internal:[port]"
         $this->s_keyman_com = "http://host.docker.internal:8054";
-        $this->api_keyman_com = "http://host.docker.internal:8098";
+        $this->api_keyman_com = "http://host.docker.internal:8058";
         $this->help_keyman_com = "http://host.docker.internal:8055";
         $this->downloads_keyman_com = "https://downloads.keyman.com"; // local dev domain is usually not available
         $this->keyman_com = "http://host.docker.internal:8053";


### PR DESCRIPTION
From @mcdurdin comment on 
https://github.com/keymanapp/api.keyman.com/pull/206#discussion_r1324079296

it would be better for api.keyman.com.localhost to use port 8058 instead of 8098 (since the other sites are in the 805x range.