### PR TITLE
chore: canonical keyboard version documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       shell: bash
       run: |
         echo "TIER_TEST" > tier.txt
-        ./build.sh build start
+        ./build.sh configure build start
       env:
         fail-fast: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ node_modules/
 resources/bootstrap.inc.sh
 resources/.bootstrap-version
 _common/
+
+# Cache of keyboard metadata, deleted on site rebuild
+keyboard/index.cache

--- a/.htaccess
+++ b/.htaccess
@@ -26,6 +26,28 @@ ErrorDocument 404 /_includes/errors/404.php?uri=%{REQUEST_URI}
 # Handle IIS bug which created links to /DEVELOPER instead of /developer
 RedirectMatch "/DEVELOPER(.*)" "/developer$1"
 
+#
+# Keyboard redirects -- must go before current-version
+#
+
+# Redirect broken legacy keyboard links
+RewriteRule "^keyboard/gff_(mdx|muz|suq)_7(/.*)?" "keyboard/gff_mym_7$2" [R,L]
+
+RewriteRule "^keyboard/redir.php(.*)$" - [END]
+
+# Rewrite /keyboard/[name][/] to /keyboard/redir.php?q=[name]
+# only if index.php does not exist in the folder
+RewriteCond "%{DOCUMENT_ROOT}/keyboard/$1/index.php" !-f
+RewriteRule "^keyboard/(?!redir.php)([^/?]+)(/)?$" "keyboard/redir.php?q=$1" [END]
+
+# Rewrite /keyboard/name/current-version[/] to /keyboard/redir.php?q=[name]
+RewriteRule "^keyboard/(?!redir.php)([^/?]+)/current-version(/)?$" "keyboard/redir.php?q=$1" [END]
+
+# Rewrite /keyboard/[name]/[version][/] to /keyboard/redir.php?q=[name]&amp;v=[version]
+# only if index.php does not exist in the folder
+RewriteCond "%{DOCUMENT_ROOT}/keyboard/$1/$2/index.php" !-f
+RewriteRule "^keyboard/(?!redir.php)([^/?]+)/([^/?]+)(/)?$" "keyboard/redir.php?q=$1&v=$2" [END]
+
 # versioning: these rules automatically redirect /foo/current-version to the
 # newest version of the documentation under /foo, e.g. 13.0, /foo/13.0, and fall
 # back to previous versions if no newer version is available. When we release a
@@ -156,24 +178,6 @@ Redirect "/kb" "/knowledge-base"
 # Redirect to kb handler
 RewriteRule "^knowledge-base/(\d+)$" "/knowledge-base/index.php?id=$1" [L]
 
-#
-# Keyboard redirects
-#
-
-# Redirect broken legacy keyboard links
-RewriteRule "^keyboard/gff_(mdx|muz|suq)_7(/.*)?" "keyboard/gff_mym_7$2" [R,L]
-
-RewriteRule "^keyboard/redir.php(.*)$" - [END]
-
-# Rewrite /keyboard/[name][/] to /keyboard/redir.php?q=[name]
-# only if index.php does not exist in the folder
-RewriteCond "%{DOCUMENT_ROOT}/keyboard/$1/index.php" !-f
-RewriteRule "^keyboard/(?!redir.php)([^/?]+)(/)?$" "keyboard/redir.php?q=$1" [END]
-
-# Rewrite /keyboard/[name]/[version][/] to /keyboard/redir.php?q=[name]&amp;v=[version]
-# only if index.php does not exist in the folder
-RewriteCond "%{DOCUMENT_ROOT}/keyboard/$1/$2/index.php" !-f
-RewriteRule "^keyboard/(?!redir.php)([^/?]+)/([^/?]+)(/)?$" "keyboard/redir.php?q=$1&v=$2" [END]
 
 
 #

--- a/_includes/header.php
+++ b/_includes/header.php
@@ -9,13 +9,15 @@
     $pagetitle = '?';
   }
   if($folders[1] == 'keyboard'){
+    $canonicalLink = "/keyboard/" . $folders[2] . "/current-version";
     head([
       'title' =>$pagetitle,
       'pagename' => isset($pagename) ? $pagename : $pagetitle,
       'css' => ['template.css','keyboard.css','keys.css'],
       'js' => ['kbd-docs.js'],
       'showMenu' => true,
-      'includeKMW' => $IncludeKeymanWeb
+      'includeKMW' => $IncludeKeymanWeb,
+      'canonicalLink' => $canonicalLink,
     ]);
   }else{
     head([

--- a/_includes/includes/head.php
+++ b/_includes/includes/head.php
@@ -55,6 +55,7 @@
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <link rel='shortcut icon' href="<?php echo $favicon; ?>">
+  <?php if(!empty($canonicalLink)) echo "  <link rel=\"canonical\" href=\"$canonicalLink\">\n"; ?>
   <?php PageVersion::WriteHead(); ?>
   <?php foreach($css as $cssFile){ ?>
     <link rel="stylesheet" type="text/css" href="<?php echo $cssFile; ?>">

--- a/_includes/includes/kb_doc_template.php
+++ b/_includes/includes/kb_doc_template.php
@@ -1,10 +1,10 @@
 <?php
   require_once('includes/servervars.php');
   require_once('includes/renderLanguageExample.php');
-  
+
   function template_finish($foot) {
     //ob_end_flush();
-    
+
     if($foot == true){
       foot();
     }
@@ -13,6 +13,7 @@
   function head($args=[]){
     // Args are title='My Page Title', css='page.css' showMenu=true/false;
     global $kbdname;
+    global $canonicalLink;
 
     // Get device
     if (strstr($_SERVER['HTTP_USER_AGENT'],'Windows')) {
@@ -26,14 +27,14 @@
     }else{
         $device = 'Unknown';
     }
-    
+
     //echo $args['includeKMW'];
     if(isset($args['includeKMW']) && $args['includeKMW'] != ''){
       $IncludeKeymanWeb = $args['includeKMW'];
     }else{
       $IncludeKeymanWeb = 1;
     }
-    
+
     if(isset($args['title'])){
         $title = $args['title'];
     }else{
@@ -65,16 +66,20 @@
     $favicon = cdn("img/favicon.ico");
     $url = $_SERVER['PHP_SELF'];
     $url = explode('/', parse_url($url, PHP_URL_PATH));
-    
+
     $kbdname ='';
-    
+
     if(sizeof($url) > 1 && $url[1] == 'keyboard') {
       $url = end($url);
-      
+
       if(preg_match('/([a-z0-9_]+)/', $url, $sub))
       {
         $kbdname = 'Keyboard_' . $sub[0];
       }
+    }
+
+    if(isset($args['canonicalLink'])) {
+      $canonicalLink = $args['canonicalLink'];
     }
 
     require_once('head.php');
@@ -84,14 +89,14 @@
     } else {
         require_once ('no-menu.php');
     }
-    
+
     $foot = isset($args['foot']) ? $args['foot'] : true;
     $shutdown = 'template_finish';
     register_shutdown_function($shutdown,$foot);
-    
+
     begin_main($args['pagename']);
   }
-    
+
   function write_breadcrumbs(){
     $crumbs = explode("/",$_SERVER["REQUEST_URI"]);
     $crumbcount = count($crumbs);
@@ -125,22 +130,22 @@
     }
     echo $crumbtrail;
   }
-  
+
   function write_version_history($pagename){
     global $kbdname;
-    
+
     //
     if(empty($kbdname)) return '';
-    
+
     $path = '../';
     $results = scandir($path);
     if(!is_array($results)){
       return '';
     }
     rsort($results);
-    
+
     if(empty($pagename)) $pagename = '';
-    
+
     $string = '<h2>All Documentation Versions</h2><ul id="version-hist">';
     $i = 0;
     foreach ($results as $result){
@@ -156,7 +161,7 @@
     $string.= '</ul><br>';
     return $string;
   }
-  
+
   function begin_main($pagename){
     global $version_history;
     write_breadcrumbs();
@@ -177,15 +182,15 @@ END;
     if(!empty($pagename)){
       $html.='<h2 class="red underline">'.$pagename.'</h2>';
     }
-    
+
     echo $html;
   }
-  
+
   function foot($args=[]){
     // Args are display=true/false;
-    
+
     global $version_history;
-    
+
     if(isset($args['display'])){
       $display = $args['display'];
     }else{
@@ -198,8 +203,8 @@ END;
     }else{
       require_once('no-footer.php');
     }
-  }  
-  
+  }
+
   function renderLanguageExamples($kbdname = '')
   {
     global $languageExamplesRendered, $kbdname;
@@ -217,7 +222,7 @@ END;
     if(!isset($languageExamplesRendered) && !empty($kbdname))
     {
       $languageExamplesRendered = true;
-      
+
       $s = renderLanguageExample($kbdname, '', '', false);
       if(!empty($s)) echo "<div id='keymanExample'>$s</div>";
     }

--- a/build.sh
+++ b/build.sh
@@ -28,6 +28,13 @@ builder_describe \
 
 builder_parse "$@"
 
+function build_help_site() {
+  build_docker_container $HELP_IMAGE_NAME $HELP_CONTAINER_NAME
+  # if there is a cached keyboard index, remove it; it will be recreated on first use
+  # TODO: build this file during site build
+  rm -f keyboard/index.cache
+}
+
 function test_docker_container() {
   # TODO: lint tests
   composer check-docker-links
@@ -36,7 +43,7 @@ function test_docker_container() {
 builder_run_action configure  bootstrap_configure
 builder_run_action clean      clean_docker_container $HELP_IMAGE_NAME $HELP_CONTAINER_NAME
 builder_run_action stop       stop_docker_container  $HELP_IMAGE_NAME $HELP_CONTAINER_NAME
-builder_run_action build      build_docker_container $HELP_IMAGE_NAME $HELP_CONTAINER_NAME
+builder_run_action build      build_help_site
 builder_run_action start      start_docker_container $HELP_IMAGE_NAME $HELP_CONTAINER_NAME $HELP_CONTAINER_DESC $HOST_HELP_KEYMAN_COM $PORT_HELP_KEYMAN_COM
 
 builder_run_action test       test_docker_container

--- a/build.sh
+++ b/build.sh
@@ -28,19 +28,12 @@ builder_describe \
 
 builder_parse "$@"
 
-function configure_help_site() {
-  bootstrap_configure
-  # if there is a cached keyboard index, remove it; it will be recreated on first use
-  # TODO: build this file during site build
-  rm -f keyboard/index.cache
-}
-
 function test_docker_container() {
   # TODO: lint tests
   composer check-docker-links
 }
 
-builder_run_action configure  configure_help_site
+builder_run_action configure  bootstrap_configure
 builder_run_action clean      clean_docker_container $HELP_IMAGE_NAME $HELP_CONTAINER_NAME
 builder_run_action stop       stop_docker_container  $HELP_IMAGE_NAME $HELP_CONTAINER_NAME
 builder_run_action build      build_docker_container $HELP_IMAGE_NAME $HELP_CONTAINER_NAME

--- a/build.sh
+++ b/build.sh
@@ -28,8 +28,8 @@ builder_describe \
 
 builder_parse "$@"
 
-function build_help_site() {
-  build_docker_container $HELP_IMAGE_NAME $HELP_CONTAINER_NAME
+function configure_help_site() {
+  bootstrap_configure
   # if there is a cached keyboard index, remove it; it will be recreated on first use
   # TODO: build this file during site build
   rm -f keyboard/index.cache
@@ -40,10 +40,10 @@ function test_docker_container() {
   composer check-docker-links
 }
 
-builder_run_action configure  bootstrap_configure
+builder_run_action configure  configure_help_site
 builder_run_action clean      clean_docker_container $HELP_IMAGE_NAME $HELP_CONTAINER_NAME
 builder_run_action stop       stop_docker_container  $HELP_IMAGE_NAME $HELP_CONTAINER_NAME
-builder_run_action build      build_help_site
+builder_run_action build      build_docker_container $HELP_IMAGE_NAME $HELP_CONTAINER_NAME
 builder_run_action start      start_docker_container $HELP_IMAGE_NAME $HELP_CONTAINER_NAME $HELP_CONTAINER_DESC $HOST_HELP_KEYMAN_COM $PORT_HELP_KEYMAN_COM
 
 builder_run_action test       test_docker_container

--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -979,7 +979,7 @@ input[type="search"] {
 	-moz-columns: 2;
 }
 
-#keyboard-support-list{
+.keyboard-support-list{
 	margin-bottom: 20px;
 	columns: 4;
 	-webkit-columns: 4;
@@ -997,11 +997,11 @@ input[type="search"] {
 	text-align: center;
 }
 
-#keyboard-support-list li, #product-support-list li, #engine-support-list li, #version-history li{
+.keyboard-support-list li, #product-support-list li, #engine-support-list li, #version-history li{
 	list-style: none !important;
 }
 
-#keyboard-support-list li a, #product-support-list li a, #engine-support-list li a, #version-history li a{
+.keyboard-support-list li a, #product-support-list li a, #engine-support-list li a, #version-history li a{
 	color: #B92034;
 	text-decoration: underline;
 }
@@ -1535,7 +1535,7 @@ body[data-device='Unknown'] #osk-tablet-container {
 		margin: 10px 10px 15px 10px;
 		text-align: center;
 	}
-	#keyboard-support-list{
+	.keyboard-support-list{
 		columns: 2;
 		-webkit-columns: 2;
 		-moz-columns: 2;

--- a/keyboard/index.php
+++ b/keyboard/index.php
@@ -1,36 +1,49 @@
 <?php
   require_once('includes/template.php');
-  $dirs = array_filter(glob('*'), 'is_dir');
-  $items = array();
-  foreach($dirs as $directory){
-    $version = '1.0';
-    $versions = array_filter(glob($directory . '/*'), 'is_dir');
-    if(count($versions) == 0) continue;
-    //var_dump($versions);
-    $filename = array_pop($versions).'/'.$directory.'.php';
-    if(!file_exists($filename)) continue;
-    $s = @file_get_contents($filename);
-    
-    if(preg_match('/\$pagename\s*=\s*[\'"](.*)[\'"]\s*;/', $s, $sub)){
-      $title = $sub[1];
-    } else if(preg_match('/\$pagetitle\s*=\s*[\'"](.*)[\'"]\s*;/', $s, $sub)){
-      $title = $sub[1];
-    } else {
-      continue; // not a keyboard help file
+
+  define('INDEX_CACHE', 'index.cache');
+
+  if(!file_exists(INDEX_CACHE)) {
+    $dirs = array_filter(glob('*'), 'is_dir');
+    $items = array('active' => array(), 'deprecated' => array());
+    foreach($dirs as $directory){
+      $version = '1.0';
+      $versions = array_filter(glob($directory . '/*'), 'is_dir');
+      if(count($versions) == 0) continue;
+      //var_dump($versions);
+      $filename = array_pop($versions).'/'.$directory.'.php';
+      if(!file_exists($filename)) continue;
+      $s = @file_get_contents($filename);
+
+      if(preg_match('/\$pagename\s*=\s*[\'"](.*)[\'"]\s*;/', $s, $sub)){
+        $title = $sub[1];
+      } else if(preg_match('/\$pagetitle\s*=\s*[\'"](.*)[\'"]\s*;/', $s, $sub)){
+        $title = $sub[1];
+      } else {
+        continue; // not a keyboard help file
+      }
+
+      if(substr($title,0,1) == '$') {
+        continue;
+      }
+
+      if(preg_match('/^(.*)\s+Keyboard\s+Help/i', $title, $sub)) {
+        $title = stripslashes($sub[1]);
+      }
+
+      $dep = strpos($title, "(deprecated)");
+      if($dep !== false) {
+        $items['deprecated'][$directory] = trim(substr($title, 0, $dep));
+      } else {
+        $items['active'][$directory] = $title;
+      }
     }
-    
-    if(substr($title,0,1) == '$') {
-      continue;
-    }
-    
-    if(preg_match('/^(.*)\s+Keyboard\s+Help/i', $title, $sub)) {
-      $title = stripslashes($sub[1]);
-    }
-    $items[$directory] = $title;
+
+    file_put_contents(INDEX_CACHE, json_encode($items));
+  } else {
+    $items = json_decode(file_get_contents(INDEX_CACHE), true);
   }
 
-  
-  
   // Required
   head([
     'title' =>'Keyman Support | Type to the world in your language',
@@ -40,11 +53,20 @@
   ]);
 ?>
 <h2 class="center">Keyboard Layouts Help Index</h2>
-<ul id="keyboard-support-list">
+<ul class="keyboard-support-list" id="keyboard-support-list">
 <?php
-  asort($items);
-  foreach ($items as $filename => $title) {
+  asort($items['active']);
+  foreach ($items['active'] as $filename => $title) {
     echo "<li><a href='$filename'>$title</a></li>";
   }
-  ?>
+?>
+</ul>
+<h2>Deprecated keyboards</h2>
+<ul class="keyboard-support-list" id="keyboard-support-list-deprecated">
+<?php
+  asort($items['deprecated']);
+  foreach ($items['deprecated'] as $filename => $title) {
+    echo "<li><a href='$filename'>$title</a></li>";
+  }
+?>
 </ul>

--- a/resources/init-container.sh
+++ b/resources/init-container.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+rm -f keyboard/index.cache
+php keyboard/index.php > /dev/null
+# php ./cdn/cdnrefresh.php


### PR DESCRIPTION
* Fixes #824: adds a /keyboard/name/current-version canonical link
* Fixes #19: separates out deprecated keyboards and lists them later
* Also improves performance of keyboard index page, caching on first use.