### PR TITLE
chore: Set line endings for .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 # Treat SVGs like images, and not like text.
 *.svg       binary
 Dockerfile  text eol=lf
-
+*.sh        eol=lf


### PR DESCRIPTION
I was trying to run the help site on a Windows host machine and ran into
```bash
/usr/bin/env: 'bash\r': No such file or directory
```

I think this got it working for me.