### PR TITLE
chore: also merge if 'behind'

### DIFF
--- a/.github/workflows/auto-merge-keyman-server-pr.yml
+++ b/.github/workflows/auto-merge-keyman-server-pr.yml
@@ -38,3 +38,4 @@ jobs:
         MERGE_FORKS: false
         MERGE_RETRY: 6
         MERGE_RETRY_SLEEP: 30000
+        MERGE_READY_STATE: clean,has_hooks,unknown,unstable,behind


### PR DESCRIPTION
If we are ready to auto-merge, but the branch is behind master, we should still auto-merge if there are no conflicts