### PR TITLE
chore: Add docs for Android HTML banner

### DIFF
--- a/developer/engine/android/17.0/KMManager/copyHTMLBannerAssets.md
+++ b/developer/engine/android/17.0/KMManager/copyHTMLBannerAssets.md
@@ -1,0 +1,42 @@
+---
+title: copyHTMLBannerAssets
+---
+
+## Summary
+The **copyHTMLBannerAssets()** method copies a folder of HTML banner assets so it's available for your keyboard app's resources.
+
+## Syntax
+
+```javascript
+KMManager.copyHTMLBannerAssets(Context context, String path)
+```
+
+### Parameters
+
+`context`
+: The context.
+
+`path`
+: Relative to the /assets folder, the folder which contains the HTML assets to display when suggestions aren't available.
+
+### Returns
+Returns `true` if HTML assets were copied, `false` otherwise.
+
+## Description
+When suggestions aren't available for a keyboard, an HTML banner is displayed instead.
+Use this method to specify any HTMl assets the banner will use to theme your keyboard app.
+
+This can be called towards the end of `SystemKeyboard.onCreate()`.
+
+## Examples
+
+### Example: Using `copyHTMLBannerAssets()`
+
+The following script illustrates the use of `copyHTMLBannerAssets()`:
+```java
+    // Copies HTML banner assets located in /assets/banner/
+    KMManager.copyHTMLBannerAssets(this, "banner");
+```
+
+## See also
+* [setHTMLBanner()](setHTMLBanner)

--- a/developer/engine/android/17.0/KMManager/copyHTMLBannerAssets.md
+++ b/developer/engine/android/17.0/KMManager/copyHTMLBannerAssets.md
@@ -33,7 +33,7 @@ This can be called towards the end of `SystemKeyboard.onCreate()`.
 ### Example: Using `copyHTMLBannerAssets()`
 
 The following script illustrates the use of `copyHTMLBannerAssets()`:
-```java
+```javascript
     // Copies HTML banner assets located in /assets/banner/
     KMManager.copyHTMLBannerAssets(this, "banner");
 ```

--- a/developer/engine/android/17.0/KMManager/copyHTMLBannerAssets.md
+++ b/developer/engine/android/17.0/KMManager/copyHTMLBannerAssets.md
@@ -24,7 +24,7 @@ Returns `true` if HTML assets were copied, `false` otherwise.
 
 ## Description
 When suggestions aren't available for a keyboard, an HTML banner is displayed instead.
-Use this method to specify any HTMl assets the banner will use to theme your keyboard app.
+Use this method to specify any HTML assets the banner will use to theme your keyboard app.
 
 This can be called towards the end of `SystemKeyboard.onCreate()`.
 

--- a/developer/engine/android/17.0/KMManager/copyHTMLBannerAssets.md
+++ b/developer/engine/android/17.0/KMManager/copyHTMLBannerAssets.md
@@ -24,9 +24,11 @@ Returns `true` if HTML assets were copied, `false` otherwise.
 
 ## Description
 When suggestions aren't available for a keyboard, an HTML banner is displayed instead.
-Use this method to specify any HTML assets the banner will use to theme your keyboard app.
+Use this method to specify any HTML assets the banner will use to theme your keyboard app. Some examples of assets would be .svg images or .css files used in your banner.
 
 This can be called towards the end of `SystemKeyboard.onCreate()`.
+
+You still need to call [setHTMLBanner()](setHTMLBanner) for Keyman Engine to assign the HTML banner for in-app and system keyboards.
 
 ## Examples
 

--- a/developer/engine/android/17.0/KMManager/index.php
+++ b/developer/engine/android/17.0/KMManager/index.php
@@ -52,6 +52,9 @@
   <dt><code><a href='canRemoveKeyboard'>canRemoveKeyboard()</a></code></dt>
   <dd>returns whether removing a keyboard is enabled, like in the keyboard picker menu</dd>
 
+  <dt><code><a href='copyHTMLBannerAssets'>copyHTMLBannerAssets()</a></code></dt>
+  <dd>copies a folder of HTML banner assets so it's available for your keyboard app's resources</dd>
+
   <dt><code><a href='createInputView'>createInputView()</a></code></dt>
   <dd>creates the input view to be used in InputMethodService</dd>
 
@@ -219,6 +222,9 @@
 
   <dt><code><strike>setHelpBubbleEnabled()</strike> (deprecated)</code></dt>
   <dd>enables or disables the help bubble</dd>
+
+  <dt><code><a href='setHTMLBanner'>setHTMLBanner()</a></code></dt>
+  <dd>sets the contents of an HTML banner for Keyman Engine to display when suggestions aren't available</dd>
 
   <dt><code><a href='setKeyboard'>setKeyboard()</a></code></dt>
   <dd>sets the keyboard to be used</dd>

--- a/developer/engine/android/17.0/KMManager/setHTMLBanner.md
+++ b/developer/engine/android/17.0/KMManager/setHTMLBanner.md
@@ -1,0 +1,43 @@
+---
+title: setHTMLBanner
+---
+
+## Summary
+The **setHTMLBanner()** method sets the HTML banner content for Keyman Engine to display when suggestions aren't available.
+
+## Syntax
+
+```javascript
+KMManager.setHTMLBanner(KeyboardType keyboardType, String content)
+```
+
+### Parameters
+
+`keyboardType`
+: KeyboardType to be used. `KEYBOARD_TYPE_INAPP` or `KEYBOARD_TYPE_SYSTEM`.
+
+`content`
+: HTML content formatted as a string.
+
+### Returns
+Returns `true` if HTML banner is set, `false` otherwise.
+
+## Description
+When suggestions aren't available for a keyboard, an HTML banner is displayed instead.
+Use this method to specify the HTMl content to display in the banner to theme your keyboard app.
+
+Note: This needs to be updated whenever the keyboard is reloaded, so call this in `SystemKeyboard.onInitializeInterface(()`.
+
+## Examples
+
+### Example: Using `setHTMLBanner()`
+
+The following script illustrates the use of `setHTMLBanner()`:
+```java
+    String KMGRAY_BANNER = "<div style=\"background: #b4b4b8; width: 100%; height: 100%; position: absolute; left: 0; top: 0\"></div>";
+    // Sets the HTML banner content
+    KMManager.setHTMLBanner(KeyboardType.KEYBOARD_TYPE_SYSTEM, KMGRAY_BANNER);
+```
+
+## See also
+* [copyHTMLBannerAssets()](copyHTMLBannerAssets)

--- a/developer/engine/android/17.0/KMManager/setHTMLBanner.md
+++ b/developer/engine/android/17.0/KMManager/setHTMLBanner.md
@@ -26,7 +26,9 @@ Returns `true` if HTML banner is set, `false` otherwise.
 When suggestions aren't available for a keyboard, an HTML banner is displayed instead.
 Use this method to specify the HTML content to display in the banner to theme your keyboard app.
 
-Note: This needs to be updated whenever the keyboard is reloaded, so call this in `SystemKeyboard.onInitializeInterface(()`.
+If the banner theme references assets (like .svg or .css files), ensure you've also called [copyHTMLBannerAssets()](copyHTMLBannerAssets).
+
+Note: The HTML banner needs to be updated whenever the keyboard is reloaded, so call this in `SystemKeyboard.onInitializeInterface(()`.
 
 ## Examples
 

--- a/developer/engine/android/17.0/KMManager/setHTMLBanner.md
+++ b/developer/engine/android/17.0/KMManager/setHTMLBanner.md
@@ -24,7 +24,7 @@ Returns `true` if HTML banner is set, `false` otherwise.
 
 ## Description
 When suggestions aren't available for a keyboard, an HTML banner is displayed instead.
-Use this method to specify the HTMl content to display in the banner to theme your keyboard app.
+Use this method to specify the HTML content to display in the banner to theme your keyboard app.
 
 Note: This needs to be updated whenever the keyboard is reloaded, so call this in `SystemKeyboard.onInitializeInterface(()`.
 
@@ -33,7 +33,7 @@ Note: This needs to be updated whenever the keyboard is reloaded, so call this i
 ### Example: Using `setHTMLBanner()`
 
 The following script illustrates the use of `setHTMLBanner()`:
-```java
+```javascript
     String KMGRAY_BANNER = "<div style=\"background: #b4b4b8; width: 100%; height: 100%; position: absolute; left: 0; top: 0\"></div>";
     // Sets the HTML banner content
     KMManager.setHTMLBanner(KeyboardType.KEYBOARD_TYPE_SYSTEM, KMGRAY_BANNER);


### PR DESCRIPTION
This documents the KMManager API calls added for controlling the Android HTML banner in keymanapp/keyman#9696

* KMManager.copyHTMLBannerAssets()
* KMManager.setHTMLBanner()