### PR TITLE
fix: Simplified Chinese help page styling

### DIFF
--- a/keyboard/cs-pinyin/1.3/cs-pinyin.php
+++ b/keyboard/cs-pinyin/1.3/cs-pinyin.php
@@ -15,10 +15,6 @@ This full version may be used with Keyman Desktop Professional 7.0 or Keyman Des
   require_once('header.php');
 ?>
 <style>
-body {
-	margin: 30px; 
-	font-family: 'Arial Unicode MS', Helvetica, sans-serif; 
-	font-size: 10pt;color: #2D2C2C;}
 img {border: none; }
 
 p {font-size: 10pt; margin:5px 0px 0px;}


### PR DESCRIPTION
Fixes #910 
Removing the page style fixes the help.keyman logo (tested on staging branch)

Not changing the keyboards repo because cs-pinyin is a legacy keyboard.

![image](https://github.com/keymanapp/help.keyman.com/assets/7358010/a03e9ae3-edf5-4325-813e-0b4602ca913a)
