### PR TITLE
Changing the link in /developer/engine/android/16.0 "See also" section 

### DIFF
--- a/developer/engine/android/16.0/index.php
+++ b/developer/engine/android/16.0/index.php
@@ -36,7 +36,7 @@ see <a href='whatsnew'>What's New</a> for breaking changes</a>
 <h2 id="See_also" name="See_also">See also</h2>
 
 <ul>
-  <li><a href="/developer/engine/android/14.0/" title="Keyman Engine for Android 15.0">Keyman Engine for Android 15.0</a></li>
+  <li><a href="/developer/engine/android/15.0/" title="Keyman Engine for Android 15.0">Keyman Engine for Android 15.0</a></li>
   <li><a href="/developer/engine/android/14.0/" title="Keyman Engine for Android 14.0">Keyman Engine for Android 14.0</a></li>
   <li><a href="/developer/engine/android/13.0/" title="Keyman Engine for Android 13.0">Keyman Engine for Android 13.0</a></li>
   <li><a href="/developer/engine/android/12.0/" title="Keyman Engine for Android 12.0">Keyman Engine for Android 12.0</a></li>

--- a/knowledge-base/kb0033.md
+++ b/knowledge-base/kb0033.md
@@ -1,7 +1,6 @@
 # HOWTO: Use Microsoft Word macros to switch keyboard and font together
 
-### **NOTE**: This archived documentation has not been updated recently and may contain information that is no longer relevant 
-<a href='https://help.keyman.com/knowledge-base/93'>(Newer version)</a>
+### **NOTE**: This archived documentation has not been updated recently and may contain information that is no longer relevant
 
 
 <p>You can use the Keyman COM API in Keyman Desktop 7.0 to control Tavultesoft Keyman from most macro languages.  An example is presented for Microsoft Word's Visual Basic for Applications.</p>

--- a/knowledge-base/kb0033.md
+++ b/knowledge-base/kb0033.md
@@ -1,6 +1,7 @@
 # HOWTO: Use Microsoft Word macros to switch keyboard and font together
 
-### **NOTE**: This archived documentation has not been updated recently and may contain information that is no longer relevant
+### **NOTE**: This archived documentation has not been updated recently and may contain information that is no longer relevant 
+<a href='https://help.keyman.com/knowledge-base/93'>(Newer version)</a>
 
 
 <p>You can use the Keyman COM API in Keyman Desktop 7.0 to control Tavultesoft Keyman from most macro languages.  An example is presented for Microsoft Word's Visual Basic for Applications.</p>


### PR DESCRIPTION
The link was pointed to 14.0 but titled as 15.0