### PR TITLE
fix: replace old-style lang codes, matching actual use

### DIFF
--- a/developer/engine/web/15.0/guide/get-started.php
+++ b/developer/engine/web/15.0/guide/get-started.php
@@ -49,8 +49,8 @@ echo codebox(<<<END
   <script>
     (function(kmw) {
       kmw.init({attachType:'auto'}).then(function() {
-        kmw.addKeyboards('@eng'); // Loads default English keyboard from Keyman Cloud (CDN)
-        kmw.addKeyboards('@tha'); // Loads default Thai keyboard from Keyman Cloud (CDN)
+        kmw.addKeyboards('@en'); // Loads default English keyboard from Keyman Cloud (CDN)
+        kmw.addKeyboards('@th'); // Loads default Thai keyboard from Keyman Cloud (CDN)
       });
     })(keyman);
   </script>

--- a/developer/engine/web/16.0/guide/get-started.php
+++ b/developer/engine/web/16.0/guide/get-started.php
@@ -49,8 +49,8 @@ echo codebox(<<<END
   <script>
     (function(kmw) {
       kmw.init({attachType:'auto'}).then(function() {
-        kmw.addKeyboards('@eng'); // Loads default English keyboard from Keyman Cloud (CDN)
-        kmw.addKeyboards('@tha'); // Loads default Thai keyboard from Keyman Cloud (CDN)
+        kmw.addKeyboards('@en'); // Loads default English keyboard from Keyman Cloud (CDN)
+        kmw.addKeyboards('@th'); // Loads default Thai keyboard from Keyman Cloud (CDN)
       });
     })(keyman);
   </script>

--- a/developer/engine/web/17.0/guide/get-started.php
+++ b/developer/engine/web/17.0/guide/get-started.php
@@ -49,8 +49,8 @@ echo codebox(<<<END
   <script>
     (function() {
       keyman.init({attachType:'auto'}).then(function() {
-        keyman.addKeyboards('@eng'); // Loads default English keyboard from Keyman Cloud (CDN)
-        keyman.addKeyboards('@tha'); // Loads default Thai keyboard from Keyman Cloud (CDN)
+        keyman.addKeyboards('@en'); // Loads default English keyboard from Keyman Cloud (CDN)
+        keyman.addKeyboards('@th'); // Loads default Thai keyboard from Keyman Cloud (CDN)
       });
     })(keyman);
   </script>


### PR DESCRIPTION
Fixes a mismatch between the language codes actually used by an example and what the example _says_ the codes are.  Obviously, in favor of the former.