### PR TITLE
cherrypick: Update production to use shared-sites v0.4

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=chore/v0.4
+readonly BOOTSTRAP_VERSION=v0.4
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 


### PR DESCRIPTION
Follows #976 
Handle this bullet point from keymanapp/keyman.com#403
> merge v0.4, new tag, update all dep sites to use the tag

for production branch