### PR TITLE
chore: no redirect for 404

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -14,7 +14,7 @@ RewriteEngine on
 RewriteBase /
 
 # Custom error messages (need to pass the original request)
-ErrorDocument 404 /_includes/errors/404.php?uri=%{REQUEST_URI}
+ErrorDocument 404 /_includes/errors/404
 
 # Handle IIS bug which created links to /DEVELOPER instead of /developer
 RedirectMatch "/DEVELOPER(.*)" "/developer$1"

--- a/_includes/errors/404.php
+++ b/_includes/errors/404.php
@@ -3,12 +3,12 @@
 
   head([
     'title' => "Page not found",
-    'index' => false
+    'index' => false,
+    'crumbs' => false,
   ]);
-  
-  // IIS uses REQUEST_URI and _SERVER; Apache using uri and _REQUEST
-  $page = empty($_REQUEST['uri']) ? $_SERVER["REQUEST_URI"] : $_REQUEST['uri'];
-  
+
+  $page = $_SERVER["REQUEST_URI"];
+
   function E($v)
   {
     $s = @htmlspecialchars($v, ENT_QUOTES, 'UTF-8');
@@ -16,13 +16,13 @@
       $s = @htmlspecialchars($v, ENT_QUOTES, 'ISO-8859-1');
     return $s;
   }
-  
+
 ?>
 <h1>Page not found</h1>
 
 <p>Sorry, we couldn't find the page <a href="<?= E($page) ?>"><?= E($page) ?></a>.</p>
 
-<p>Please use the blue Support tab at the bottom of this page to tell us about this problem.</p>
+<p>Please tell us about this problem on the <a href="https://community.software.sil.org/c/keyman" target="_blank">Keyman Community</a>.</p>
 
 <h2>Search Keyman Help</h2>
 


### PR DESCRIPTION
The .php extension on the 404 ErrorDocument directive was causing Apache to do a redirect. Removing this means that the original url is maintained.

Also did a little bit of cleanup to the error page at the same time:
* removed (unhelpful) breadcrumbs
* gave a direct link to Keyman Community
* removed IIS-specific code