### PR TITLE
fix: products/windows/14.0/docs redirects

### DIFF
--- a/products/windows/.htaccess
+++ b/products/windows/.htaccess
@@ -5,6 +5,8 @@ RedirectMatch "versionhistory.php" "/products/windows/version-history/"
 # 14.0 docs redirects
 RedirectMatch "/products/windows/14.0/docs/context_installkeyboard.php" "/products/windows/14.0/context/install-keyboard"
 RedirectMatch "/products/windows/14.0/docs/basic_enable_keyboard.php" "/products/windows/14.0/basic/enable-or-disable-keyboard"
+RedirectMatch "/products/windows/14.0/docs/context_configuration_keyboards.php" "/products/windows/14.0/context/configuration-keyboards"
+RedirectMatch "/products/windows/14.0/docs/start_tutorial.php" "/products/windows/14.0/start/tutorial"
 RedirectMatch "/products/windows/14.0/docs/basic_config_menu.php" "/products/windows/14.0/basic/config/"
 RedirectMatch "/products/windows/14.0/docs/context_onlineupdate.php" "/products/windows/14.0/context/online-update"
 RedirectMatch "/products/windows/14.0/docs/context_font_helper.php" "/products/windows/14.0/start/font"

--- a/products/windows/.htaccess
+++ b/products/windows/.htaccess
@@ -1,3 +1,11 @@
 
 # Redirect versionhistory.php (from Keyman static docs)
 RedirectMatch "versionhistory.php" "/products/windows/version-history/"
+
+# 14.0 docs redirects
+RedirectMatch "/products/windows/14.0/docs/context_installkeyboard.php" "/products/windows/14.0/context/install-keyboard"
+RedirectMatch "/products/windows/14.0/docs/basic_enable_keyboard.php" "/products/windows/14.0/basic/enable-or-disable-keyboard"
+RedirectMatch "/products/windows/14.0/docs/basic_config_menu.php" "/products/windows/14.0/basic/config/"
+RedirectMatch "/products/windows/14.0/docs/context_onlineupdate.php" "/products/windows/14.0/context/online-update"
+RedirectMatch "/products/windows/14.0/docs/context_font_helper.php" "/products/windows/14.0/start/font"
+RedirectMatch "/products/windows/14.0/docs/start_download-install_keyman.php" "products/windows/14.0/start/download-and-install-keyman"


### PR DESCRIPTION
Fixes #1033 adding /products/windows/14.0/docs redirects

There's still a long list that Google flagged - TODO for another day.