### PR TITLE
docs(windows): add knowledge base article for distributed keyboard installation

### DIFF
--- a/knowledge-base/kb0112.md
+++ b/knowledge-base/kb0112.md
@@ -1,0 +1,47 @@
+# Keyman for Windows: Distributed Installation of Keyboards
+
+## Installing Keyman Package Files using kmshell.exe
+
+**Introduction:**
+This knowledge base provide the steps to to install keyboards remotely and enable them for a non-elevated user. The key is that the registration for language and the keyboard needs to be run as the user who needs the keyboard enabled.
+
+This guide will use `kmshell.exe` and will work for Keyman 14 and above.
+
+4. **Locating `kmshell.exe`:**
+   - Typically, `kmshell.exe` is located in `%ProgramFiles(x86)%\Keyman\Keyman Desktop\kmshell.exe`.
+   - Alternatively, the path can be retrieved from the registry setting `HKLM\Software\WOW6432Node\Keyman\Keyman Desktop\root`.
+
+**Procedure:**
+
+1. **Keyboard Package Installation:**
+   - Execute the following command in an elevated command prompt to install the package and make it available for all users:
+     ```
+     kmshell -s -i filename.kmp
+     ```
+
+2. **Language registration for each user:**
+   - With Keyman 14 and above, an extra step is necessary for each user to set up language registration for the keyboard within the package.
+   - Run the following command in a non-elevated command prompt for each user:
+     ```
+     kmshell -s -ikl KeyboardID BCP47Tag
+     ```
+     - Replace 'KeyboardID' with the appropriate identifier for the keyboard (usually the same as the package filename without `.kmp`).
+     - Replace 'BCP47Tag' with the language tag, which can be found in Keyman Configuration.
+
+3. **Example:**
+   - As an example, let's consider the installation of the BJ-OjiCree keyboard (Kingfisher):
+     - KeyboardID: `bj_cree_east`
+     - BCP47Tag: `crl-Cans-CA`
+   - Installation commands:
+     - Elevated session:
+       ```
+       kmshell -s -i bj_cree_east.kmp.kmp
+       ```
+     - Non-elevated session (for each user):
+       ```
+       kmshell -s -ikl bj_cree_east crl-Cans-CA
+       ```
+
+
+**Automation:**
+- Incorporating these installation steps with remote deployment and management software tools should achieve automation

--- a/knowledge-base/kb0112.md
+++ b/knowledge-base/kb0112.md
@@ -30,9 +30,13 @@ This guide will use `kmshell.exe` and will work for Keyman 14 and above.
      - Replace 'BCP47Tag' with the language tag, which can be found in Keyman Configuration.
 
 3. **Example:**
-   - As an example, let's consider the installation of the BJ-OjiCree keyboard (Kingfisher):
+   - As an example, let's consider the installation of the **BJCreeUNI** (east) keyboard.
+     Normally, the KeyboardID will be the same as the package filename (sans .kmp). You can check it by installing the package locally and viewing the details in Keyman Configuration. Similarly, the BCP 47 tag (e.g.en-US) can be found in Keyman Configuration installed keyboard’s details looking at the languages label.
      - KeyboardID: `bj_cree_east`
      - BCP47Tag: `crl-Cans-CA`
+  
+
+  
    - Installation commands:
      - Elevated session:
        ```
@@ -45,4 +49,4 @@ This guide will use `kmshell.exe` and will work for Keyman 14 and above.
 
 
 **Automation:**
-- Incorporating these installation steps with remote deployment and management software tools should achieve automation. Insure each call of kmshell as described above needs to complete before running the next command.
+- Incorporating these installation steps with remote deployment and management software tools should achieve automation. Ensure each call of kmshell has completed before running the next command.

--- a/knowledge-base/kb0112.md
+++ b/knowledge-base/kb0112.md
@@ -40,7 +40,7 @@ This guide will use `kmshell.exe` and will work for Keyman 14 and above.
    - Installation commands:
      - Elevated session:
        ```
-       kmshell -s -i bj_cree_east.kmp.kmp
+       kmshell -s -i bj_cree_east.kmp
        ```
      - Non-elevated session (for each user):
        ```

--- a/knowledge-base/kb0112.md
+++ b/knowledge-base/kb0112.md
@@ -7,7 +7,7 @@ This knowledge base provide the steps to to install keyboards remotely and enabl
 
 This guide will use `kmshell.exe` and will work for Keyman 14 and above.
 
-4. **Locating `kmshell.exe`:**
+**Locating `kmshell.exe`:**
    - Typically, `kmshell.exe` is located in `%ProgramFiles(x86)%\Keyman\Keyman Desktop\kmshell.exe`.
    - Alternatively, the path can be retrieved from the registry setting `HKLM\Software\WOW6432Node\Keyman\Keyman Desktop\root`.
 
@@ -21,6 +21,7 @@ This guide will use `kmshell.exe` and will work for Keyman 14 and above.
 
 2. **Language registration for each user:**
    - With Keyman 14 and above, an extra step is necessary for each user to set up language registration for the keyboard within the package.
+   - Ensure the previous kmshell process has completed before running the next command.
    - Run the following command in a non-elevated command prompt for each user:
      ```
      kmshell -s -ikl KeyboardID BCP47Tag
@@ -44,4 +45,4 @@ This guide will use `kmshell.exe` and will work for Keyman 14 and above.
 
 
 **Automation:**
-- Incorporating these installation steps with remote deployment and management software tools should achieve automation
+- Incorporating these installation steps with remote deployment and management software tools should achieve automation. Insure each call of kmshell as described above needs to complete before running the next command.

--- a/knowledge-base/kb0112.md
+++ b/knowledge-base/kb0112.md
@@ -1,9 +1,9 @@
-# Keyman for Windows: Distributed Installation of Keyboards
+# Keyman for Windows: Scripted Installation of Keyboards
 
 ## Installing Keyman Package Files using kmshell.exe
 
 **Introduction:**
-This knowledge base provide the steps to to install keyboards remotely and enable them for a non-elevated user. The key is that the registration for language and the keyboard needs to be run as the user who needs the keyboard enabled.
+This article documents the process for installation of a Keyman keyboard package via command line or script. This is particularly helpful when deploying keyboards to multiple computers. The process is split into an elevated step to install the keyboard and register it in the system, and a current-user step, to link the keyboard to a language for the user.
 
 This guide will use `kmshell.exe` and will work for Keyman 14 and above.
 
@@ -14,7 +14,7 @@ This guide will use `kmshell.exe` and will work for Keyman 14 and above.
 **Procedure:**
 
 1. **Keyboard Package Installation:**
-   - Execute the following command in an elevated command prompt to install the package and make it available for all users:
+   - Execute the following command in an elevated command prompt to install the package `filename.kmp` and make it available for all users:
      ```
      kmshell -s -i filename.kmp
      ```
@@ -30,8 +30,8 @@ This guide will use `kmshell.exe` and will work for Keyman 14 and above.
      - Replace 'BCP47Tag' with the language tag, which can be found in Keyman Configuration.
 
 3. **Example:**
-   - As an example, let's consider the installation of the **BJCreeUNI** (east) keyboard.
-     Normally, the KeyboardID will be the same as the package filename (sans .kmp). You can check it by installing the package locally and viewing the details in Keyman Configuration. Similarly, the BCP 47 tag (e.g.en-US) can be found in Keyman Configuration installed keyboard’s details looking at the languages label.
+   - As an example, let's consider the installation of the **BJCreeUNI (east)** keyboard.
+     Normally, the KeyboardID will be the same as the package filename (sans .kmp). You can check it by installing the package locally and viewing the details in Keyman Configuration. Similarly, the BCP 47 tag (e.g. en-US) can be found in Keyman Configuration’s installed keyboard’s details, looking at the languages label.
      - KeyboardID: `bj_cree_east`
      - BCP47Tag: `crl-Cans-CA`
   


### PR DESCRIPTION
The steps to install a keyboard and then enable it for non-admin users or even each user on the local machine is not documented. This knowldege base article addresses that. 