### PR TITLE
docs(windows): update kmshell command line switch options knowledge base

### DIFF
--- a/knowledge-base/kb0098.md
+++ b/knowledge-base/kb0098.md
@@ -8,19 +8,51 @@ The following command line arguments are available:
 
 Argument | Description
 ---------|-------------
+`-a` | Loads the Keyman Configuration user interface
+`-basekeyboard` | Loads the "Set Base Keyboard" user interface
 `-c` | Start Keyman Configuration user interface
 `-i filename[=bcp47]` | Install a keyboard (.kmx) or package (.kmp) file, optionally associating with a specific language
+`-ikl KeyboardID BCP47Tag` | <BCP47Tag> language registration for the keyboard <KeyboardID> and enable the keyboard.
+`-f` | Forces an update check (overiding only check every 7 days) used with the -ouc switch
 `-uk filename.kmx` | Uninstall a keyboard (.kmx file)
 `-up filename.kmp` | Uninstall a package (.kmp file)
 `-h` | Open Keyman help contents
+`-keepintouch` | Opens the Keep in touch page in the users default web browser (also opens a blank winform UI)
+`-kw` | Show the welcome screen for the keyboard name supplied as the first argument.e.g. -kw keyboard_name
+`-nowelcome` | To be used in conjunction with -i and it stops the welcome screen from showing
 `-t` | Start Keyman text editor
 `-ouc` | Check for updates online and prompt user if updates are found
 `-kw package` | Show help for the installed keyboard package
 `-kp keyboard` | Start print wizard for on screen keyboard for the keyboard
 `-s` | Where relevant, run silently, without user interface prompts
+`-settings`	| Loads the Keyman System Settings an advanced configuration user interface 
+`-showhelp` |	Shows the help user interface
+`-splash` |	Show splash screen 
+`-t` |	Opens the Keyman Text Editor
+
+`-upgradekeyboards` | Upgrade keyboards
+`-disablepackages`  | Disable packages
+`-q` | `Provide query string separated by spaces`
 
 
 If `kmshell.exe` is run as an elevated command, then the command will run in local machine context, otherwise it will affect only the current user. `-i`, `-uk`, `-up` all require elevation to succeed.
+## Internal - used to call a process to run in the elevated context 
+
+Argument | Description
+---------|-------------
+`-default-lang`	| With parameters 1 = DefaultBCP47 2 = DefaultLangID. Internal used so that the elevated user can use the current users default language ID.
+`-firstrun` | Sets up configuration for both local-machine and current user.
+`-install-tip` | For language (current user ) parameters LangID KeyboarID BCP47Code UserDefaultLangparameterString
+`-install-tips-for-packages`	|
+`-ou`	| Called inside Online Update Check when when elevated permissions are needed.
+`-register-tip`	| Register the TIP processor for language? (elevelated user) LangID KeyboarID BCP47Code TemporaryKeyboard ID Registration Required
+`-upgradekeyboards`	| Backup and import keyboards when upgrading keyman. This is run after installation; it is idempotent and will upgrade all keyboards from earlier versions to version 14+" Options are: `-upgradekeyboards=13,backup`;`-upgradekeyboards=13,import`;`-upgradekeyboards=13,admin`
+`-upgrademnemoniclayout`	| Upgrade mnemonic keyboard layouts
+`-defaultuilanguage`	| Sets the default user interface language used in -firstrun
+`-disablePackages` |	Disables packages used with `-firstrun` | it can set all packages disabled.
+`-parentwindow` |	Has one parameter which is the parent window id.
+
+
 
 ## History
 


### PR DESCRIPTION
Added the missing switch commands including commands that are used internally to run elevated configuration commands