### PR TITLE
chore: Fix titles about HTMLBanner

### DIFF
--- a/developer/engine/android/17.0/KMManager/copyHTMLBannerAssets.md
+++ b/developer/engine/android/17.0/KMManager/copyHTMLBannerAssets.md
@@ -26,7 +26,7 @@ Returns `true` if HTML assets were copied, `false` otherwise.
 When suggestions aren't available for a keyboard, an HTML banner is displayed instead.
 Use this method to specify any HTML assets the banner will use to theme your keyboard app. Some examples of assets would be .svg images or .css files used in your banner.
 
-This can be called towards the end of `SystemKeyboard.onCreateInputView()`.
+This can be called towards the end of `SystemKeyboard.onCreate()`.
 
 You still need to call [setHTMLBanner()](setHTMLBanner) for Keyman Engine to assign the HTML banner for in-app and system keyboards.
 

--- a/developer/engine/android/17.0/KMManager/copyHTMLBannerAssets.md
+++ b/developer/engine/android/17.0/KMManager/copyHTMLBannerAssets.md
@@ -1,5 +1,5 @@
 ---
-title: copyHTMLBannerAssets
+title: KMManager.copyHTMLBannerAssets
 ---
 
 ## Summary
@@ -26,7 +26,7 @@ Returns `true` if HTML assets were copied, `false` otherwise.
 When suggestions aren't available for a keyboard, an HTML banner is displayed instead.
 Use this method to specify any HTML assets the banner will use to theme your keyboard app. Some examples of assets would be .svg images or .css files used in your banner.
 
-This can be called towards the end of `SystemKeyboard.onCreate()`.
+This can be called towards the end of `SystemKeyboard.onCreateInputView()`.
 
 You still need to call [setHTMLBanner()](setHTMLBanner) for Keyman Engine to assign the HTML banner for in-app and system keyboards.
 

--- a/developer/engine/android/17.0/KMManager/setHTMLBanner.md
+++ b/developer/engine/android/17.0/KMManager/setHTMLBanner.md
@@ -28,7 +28,7 @@ Use this method to specify the HTML content to display in the banner to theme yo
 
 If the banner theme references assets (like .svg or .css files), ensure you've also called [copyHTMLBannerAssets()](copyHTMLBannerAssets).
 
-Note: The HTML banner needs to be updated whenever the keyboard is re-created, so call this towards the end of `SystemKeyboard.onCreateInputView(()`.
+Note: The HTML banner needs to be updated whenever the keyboard is reloaded, so call this in `SystemKeyboard.onInitializeInterface(()`.
 
 ## Examples
 

--- a/developer/engine/android/17.0/KMManager/setHTMLBanner.md
+++ b/developer/engine/android/17.0/KMManager/setHTMLBanner.md
@@ -1,5 +1,5 @@
 ---
-title: setHTMLBanner
+title: KMManager.setHTMLBanner
 ---
 
 ## Summary
@@ -28,7 +28,7 @@ Use this method to specify the HTML content to display in the banner to theme yo
 
 If the banner theme references assets (like .svg or .css files), ensure you've also called [copyHTMLBannerAssets()](copyHTMLBannerAssets).
 
-Note: The HTML banner needs to be updated whenever the keyboard is reloaded, so call this in `SystemKeyboard.onInitializeInterface(()`.
+Note: The HTML banner needs to be updated whenever the keyboard is re-created, so call this towards the end of `SystemKeyboard.onCreateInputView(()`.
 
 ## Examples
 


### PR DESCRIPTION
(edit)
~Goes with keymanapp/keyman#11078 about updating the descriptions on Keyman Engine for Android HTMLBanner APIs.~

keymanapp/keyman#11078 replaced by keymanapp/keyman#11108, so this PR

~Also~ fixes the titles so they're in the same hierarchy as all the other KMManager pages.