### PR TITLE
chore: seed Developer 18.0 documentation

### DIFF
--- a/developer/18.0/index.md
+++ b/developer/18.0/index.md
@@ -1,0 +1,44 @@
+---
+title: Keyman Developer 18.0 User Guide
+---
+
+Need help using Keyman Developer to create your keyboard layouts? You'll
+find everything you need here, including product documentation, guides
+and tutorials, and full reference information.
+
+<!--
+
+TODO: seed rest of 18.0 documentation
+
+## Guides and Tutorials
+-   [What is Keyman Developer?](guides/intro)
+-   [What's new in 17.0](whats-new)
+-   [Developing Keyman keyboard layouts](guides/develop)
+-   [Testing Keyman keyboards](guides/test)
+-   [Distributing Keyman keyboards](guides/distribute)
+-   [What is a lexical model?](guides/lexical-models)
+-   [Developing a lexical model](guides/lexical-models/tutorial)
+
+## Reference
+-   [Keyman keyboard language reference](../language/reference)
+-   [Keyman keyboard language guide](../language/guide)
+-   [Customising Keyman Engine for Desktop](../engine/desktop)
+-   [Error codes, File types and Tools](reference/)
+-   [Keyman Developer user interface](context/)
+-   [Additional Notes](main/)
+-   [Version History](../version-history/)
+
+-->
+
+## Ask for Help
+-   [Ask other users in the SIL Keyman Community](https://community.software.sil.org/c/keyman)
+
+## Other Resources
+
+-   [Keyboard Quality White Paper](/developer/whitepaper1.1.pdf)
+-   [Knowledge Base](/kb)
+-   [Keyman Desktop Help](/products/desktop)
+-   [Keyman Engine for Desktop](/developer/engine/desktop/current-version/)
+-   [Keyman Engine for Web](/developer/engine/web/)
+-   [Keyman Engine for iPhone and iPad](/developer/engine/iphone-and-ipad/current-version/)
+-   [Keyman Engine for Android](/developer/engine/android/current-version/)

--- a/developer/18.0/reference/index.md
+++ b/developer/18.0/reference/index.md
@@ -1,0 +1,17 @@
+---
+title: Keyman Developer Reference
+---
+
+<!--
+TODO: seed 18.0 documentation
+
+* [Keyman keyboard language guide and reference](/developer/language)
+* [Command line compiler - kmc](kmc)
+* [Compiler messages](messages)
+* [Keyman keyboard source file layout](file-layout)
+* [File types](file-types)
+* [BCP 47 language codes](bcp-47)
+* [Tools](tools)
+* [Custom editor themes](editor-themes)
+* [User settings](user-settings)
+-->


### PR DESCRIPTION
Note: only including index and reference folders so that we can merge automatic PRs for kmc api and clean the PR queue.

This is not a full 18.0 documentation seed, which should wait until 17.0 documentation refresh is complete.