### PR TITLE
fix: More htmlentities in $pagetitles

### DIFF
--- a/keyboard/gff_blin/1.1/gff_blin.php
+++ b/keyboard/gff_blin/1.1/gff_blin.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = 'GFF Blin';
-  $pagetitle = 'The Ge&rsquo;ez Frontier Foundation Keyboard for Blin Language';
+  $pagetitle = 'The Geʾez Frontier Foundation Keyboard for Blin Language';
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_blin/1.2/gff_blin.php
+++ b/keyboard/gff_blin/1.2/gff_blin.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = 'GFF Blin';
-  $pagetitle = 'The Ge&rsquo;ez Frontier Foundation Keyboard for Blin Language';
+  $pagetitle = 'The Geʾez Frontier Foundation Keyboard for Blin Language';
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_blin/1.3/gff_blin.php
+++ b/keyboard/gff_blin/1.3/gff_blin.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = 'GFF Blin';
-  $pagetitle = 'The Ge&rsquo;ez Frontier Foundation Keyboard for Blin Language';
+  $pagetitle = 'The Geʾez Frontier Foundation Keyboard for Blin Language';
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_blin/1.4.1/gff_blin.php
+++ b/keyboard/gff_blin/1.4.1/gff_blin.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = 'GFF Blin';
-  $pagetitle = 'The Ge&rsquo;ez Frontier Foundation Keyboard for Blin Language';
+  $pagetitle = 'The Geʾez Frontier Foundation Keyboard for Blin Language';
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_blin/1.4.2/gff_blin.php
+++ b/keyboard/gff_blin/1.4.2/gff_blin.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = 'GFF Blin';
-  $pagetitle = 'The Ge&rsquo;ez Frontier Foundation Keyboard for Blin Language';
+  $pagetitle = 'The Geʾez Frontier Foundation Keyboard for Blin Language';
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_blin/1.4/gff_blin.php
+++ b/keyboard/gff_blin/1.4/gff_blin.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = 'GFF Blin';
-  $pagetitle = 'The Ge&rsquo;ez Frontier Foundation Keyboard for Blin Language';
+  $pagetitle = 'The Geʾez Frontier Foundation Keyboard for Blin Language';
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_blin/1.5.1/gff_blin.php
+++ b/keyboard/gff_blin/1.5.1/gff_blin.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = 'GFF Blin';
-  $pagetitle = 'The Ge&rsquo;ez Frontier Foundation Keyboard for Blin Language';
+  $pagetitle = 'The Geʾez Frontier Foundation Keyboard for Blin Language';
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_blin/1.5.2/gff_blin.php
+++ b/keyboard/gff_blin/1.5.2/gff_blin.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = 'GFF Blin';
-  $pagetitle = 'The Ge&rsquo;ez Frontier Foundation Keyboard for Blin Language';
+  $pagetitle = 'The Geʾez Frontier Foundation Keyboard for Blin Language';
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_blin/1.5/gff_blin.php
+++ b/keyboard/gff_blin/1.5/gff_blin.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = 'GFF Blin';
-  $pagetitle = 'The Ge&rsquo;ez Frontier Foundation Keyboard for Blin Language';
+  $pagetitle = 'The Geʾez Frontier Foundation Keyboard for Blin Language';
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_gurage/0.6.1/gff_gurage.php
+++ b/keyboard/gff_gurage/0.6.1/gff_gurage.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Ge&rsquo;ez Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Geʾez Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_gurage/0.6.10/gff_gurage.php
+++ b/keyboard/gff_gurage/0.6.10/gff_gurage.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Ge&rsquo;ez Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Geʾez Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_gurage/0.6.11/gff_gurage.php
+++ b/keyboard/gff_gurage/0.6.11/gff_gurage.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Ge&rsquo;ez Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Geʾez Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_gurage/0.6.12/gff_gurage.php
+++ b/keyboard/gff_gurage/0.6.12/gff_gurage.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Ge&rsquo;ez Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Geʾez Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_gurage/0.6.2/gff_gurage.php
+++ b/keyboard/gff_gurage/0.6.2/gff_gurage.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Ge&rsquo;ez Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Geʾez Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_gurage/0.6.9/gff_gurage.php
+++ b/keyboard/gff_gurage/0.6.9/gff_gurage.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Ge&rsquo;ez Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Geʾez Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_gurage/0.6/gff_gurage.php
+++ b/keyboard/gff_gurage/0.6/gff_gurage.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Ge&rsquo;ez Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Geʾez Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_gurage/0.7/gff_gurage.php
+++ b/keyboard/gff_gurage/0.7/gff_gurage.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Ge&rsquo;ez Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Geʾez Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_gurage/0.8.1/gff_gurage.php
+++ b/keyboard/gff_gurage/0.8.1/gff_gurage.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for the Gurage Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for the Gurage Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_gurage/0.8/gff_gurage.php
+++ b/keyboard/gff_gurage/0.8/gff_gurage.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for the Gurage Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for the Gurage Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_gurage/0.9.1/gff_gurage.php
+++ b/keyboard/gff_gurage/0.9.1/gff_gurage.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for the Gurage Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for the Gurage Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_gurage/0.9/gff_gurage.php
+++ b/keyboard/gff_gurage/0.9/gff_gurage.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for the Gurage Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for the Gurage Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_gurage_legacy/0.1/gff_gurage_legacy.php
+++ b/keyboard/gff_gurage_legacy/0.1/gff_gurage_legacy.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Ge&rsquo;ez Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Geʾez Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_gurage_legacy/0.11/gff_gurage_legacy.php
+++ b/keyboard/gff_gurage_legacy/0.11/gff_gurage_legacy.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Ge&rsquo;ez Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Geʾez Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_tigre/1.0/gff_tigre.php
+++ b/keyboard/gff_tigre/1.0/gff_tigre.php
@@ -1,6 +1,6 @@
 <?php
   $pagename = "GFF Tigre";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Tigre";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Tigre";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_tigrinya_eritrea/1.1/gff_tigrinya_eritrea.php
+++ b/keyboard/gff_tigrinya_eritrea/1.1/gff_tigrinya_eritrea.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Eritrean Tigrinya";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Eritrean Tigrinya";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Eritrean Tigrinya";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_tigrinya_eritrea/1.2/gff_tigrinya_eritrea.php
+++ b/keyboard/gff_tigrinya_eritrea/1.2/gff_tigrinya_eritrea.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Eritrean Tigrinya";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Eritrean Tigrinya";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Eritrean Tigrinya";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_tigrinya_eritrea/1.3.1/gff_tigrinya_eritrea.php
+++ b/keyboard/gff_tigrinya_eritrea/1.3.1/gff_tigrinya_eritrea.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Eritrean Tigrinya";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Eritrean Tigrinya";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Eritrean Tigrinya";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_tigrinya_eritrea/1.3.2/gff_tigrinya_eritrea.php
+++ b/keyboard/gff_tigrinya_eritrea/1.3.2/gff_tigrinya_eritrea.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Eritrean Tigrinya";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Eritrean Tigrinya";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Eritrean Tigrinya";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_tigrinya_eritrea/1.3/gff_tigrinya_eritrea.php
+++ b/keyboard/gff_tigrinya_eritrea/1.3/gff_tigrinya_eritrea.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Eritrean Tigrinya";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Eritrean Tigrinya";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Eritrean Tigrinya";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/keyboard/gff_tigrinya_eritrea/2.0/gff_tigrinya_eritrea.php
+++ b/keyboard/gff_tigrinya_eritrea/2.0/gff_tigrinya_eritrea.php
@@ -1,6 +1,6 @@
 <?php
   $pagename = "GFF Eritrean Tigrinya";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Eritrean Tigrinya";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Eritrean Tigrinya";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 


### PR DESCRIPTION
Follows #1209 

This removes the htmlentities used in `$pagetitles`