### PR TITLE
ci: Update GHA checkout to 4.1.5

### DIFF
--- a/.github/workflows/auto-approve-and-merge-keyman-server-pr.yml
+++ b/.github/workflows/auto-approve-and-merge-keyman-server-pr.yml
@@ -17,7 +17,7 @@ jobs:
     permissions: write-all
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.1.5
       with:
         sparse-checkout: |
           README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v4.1.5
 
     # Build the docker image and create link to vendor/ dependencies
     - name: Build the Docker image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.5
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx


### PR DESCRIPTION
While investigating the failed CI build on 
https://github.com/keymanapp/help.keyman.com/actions/runs/9009359924

I noticed the GHA notice:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3.5.2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

checkout 4.1.0 updates default runtime to node20