### PR TITLE
fix: keyman.options has become keyman.config.options

### DIFF
--- a/cdn/dev/js/kbd-docs.js
+++ b/cdn/dev/js/kbd-docs.js
@@ -75,7 +75,7 @@ function loaded(){
 
     var url = location.pathname.split('/');
     var keyboardName = url[url.length-3], keyboardVersion = url[url.length-2];
-    var keyboardPath = keyman.options['keyboards'] + keyboardName + '/' + keyboardVersion + '/' + keyboardName + '-' + keyboardVersion + '.js';
+    var keyboardPath = keyman.config.options['keyboards'] + keyboardName + '/' + keyboardVersion + '/' + keyboardName + '-' + keyboardVersion + '.js';
 
     var fontFamily = null, fontSource = null;
 


### PR DESCRIPTION
`keyman.options` was not a published API so there was no guarantee of stability. It changed to `keyman.config.options` in 17.0. Note: this is not a published API either.

Fixes: keymanapp/keyman#11466
Fixes: HELP-KEYMAN-COM-BWG