### PR TITLE
docs: Add getOrientation, getWindowDensity, and getWindowSize APIs

### DIFF
--- a/developer/engine/android/18.0/KMManager/getOrientation.md
+++ b/developer/engine/android/18.0/KMManager/getOrientation.md
@@ -15,14 +15,12 @@ KMManager.getOrientation(Context context)
 `context`
 : The context.
 
-### ReturnsPoint = 
+### Returns
 Returns the device orientation as an int, one of: 
 
-`Configuration.ORIENTATION_PORTRAIT` (`1`), 
-
-`Configuration.ORIENTATION_LANDSCAPE` (`2`)
-
-`Configuration.ORIENTATION_UNDEFINED` (`0`)
+* `Configuration.ORIENTATION_PORTRAIT` (`1`)
+* `Configuration.ORIENTATION_LANDSCAPE` (`2`)
+* `Configuration.ORIENTATION_UNDEFINED` (`0`)
 
 ## Description
 Use this method to get the current orientation of the device
@@ -31,7 +29,7 @@ Use this method to get the current orientation of the device
 
 ### Example: Using `getOrientation()`
 
-The following script illustrates the use of `getOrientation()`:
+The following code illustrates the use of `getOrientation()`:
 ```java
     int orientation = KMManager.getOrientation(context);
 ```

--- a/developer/engine/android/18.0/KMManager/getOrientation.md
+++ b/developer/engine/android/18.0/KMManager/getOrientation.md
@@ -1,0 +1,37 @@
+---
+title: KMManager.getOrientation()
+---
+
+## Summary
+
+The `getOrientation()` method returns the current orientation of the device.
+
+## Syntax
+
+```java
+KMManager.getOrientation(Context context)
+```
+
+`context`
+: The context.
+
+### ReturnsPoint = 
+Returns the device orientation as an int, one of: 
+
+`Configuration.ORIENTATION_PORTRAIT` (`1`), 
+
+`Configuration.ORIENTATION_LANDSCAPE` (`2`)
+
+`Configuration.ORIENTATION_UNDEFINED` (`0`)
+
+## Description
+Use this method to get the current orientation of the device
+
+## Examples
+
+### Example: Using `getOrientation()`
+
+The following script illustrates the use of `getOrientation()`:
+```java
+    int orientation = KMManager.getOrientation(context);
+```

--- a/developer/engine/android/18.0/KMManager/getWindowDensity.md
+++ b/developer/engine/android/18.0/KMManager/getWindowDensity.md
@@ -1,0 +1,34 @@
+---
+title: KMManager.getWindowDensity()
+---
+
+## Summary
+
+The `getWindowDensity()` method returns the density of the window.
+
+## Syntax
+
+```java
+KMManager.getWindowDensity(Context context)
+```
+
+`context`
+: The context.
+
+### Returns
+Returns the density 
+
+## Description
+Use this method to get the [density](https://developer.android.com/reference/android/util/DisplayMetrics#density) of the window. This is a scaling factor for the Density Independent Pixel (DIP) unit. 
+
+## Examples
+
+### Example: Using `getWindowDensity()`
+
+The following script illustrates the use of `getWindowDensity()`:
+```java
+    float density = KMManager.getWindowDensity(context);
+```
+
+## See Also
+* [getWindowSize](getWindowSize)

--- a/developer/engine/android/18.0/KMManager/getWindowDensity.md
+++ b/developer/engine/android/18.0/KMManager/getWindowDensity.md
@@ -25,7 +25,7 @@ Use this method to get the [density](https://developer.android.com/reference/and
 
 ### Example: Using `getWindowDensity()`
 
-The following script illustrates the use of `getWindowDensity()`:
+The following code illustrates the use of `getWindowDensity()`:
 ```java
     float density = KMManager.getWindowDensity(context);
 ```

--- a/developer/engine/android/18.0/KMManager/getWindowSize.md
+++ b/developer/engine/android/18.0/KMManager/getWindowSize.md
@@ -25,7 +25,7 @@ Use this method to get the size of the entire display. It may or may not include
 
 ### Example: Using `getWindowSize()`
 
-The following script illustrates the use of `getWindowSize()`:
+The following code illustrates the use of `getWindowSize()`:
 ```java
     Point size = KMManager.getWindowSize(context);
     int screenHeight = size.y;

--- a/developer/engine/android/18.0/KMManager/getWindowSize.md
+++ b/developer/engine/android/18.0/KMManager/getWindowSize.md
@@ -1,0 +1,35 @@
+---
+title: KMManager.getWindowSize()
+---
+
+## Summary
+
+The `getWindowSize()` method returns the size of the area the window would occupy.
+
+## Syntax
+
+```java
+KMManager.getWindowSize(Context context)
+```
+
+`context`
+: The context.
+
+### Returns
+Returns the window size (native resolution) of the display as (int x, int y).
+
+## Description
+Use this method to get the size of the entire display. It may or may not include [system decoration areas](https://developer.android.com/reference/android/view/Display)
+
+## Examples
+
+### Example: Using `getWindowSize()`
+
+The following script illustrates the use of `getWindowSize()`:
+```java
+    Point size = KMManager.getWindowSize(context);
+    int screenHeight = size.y;
+```
+
+## See also
+* [getWindowDensity](getWindowDensity)

--- a/developer/engine/android/18.0/KMManager/getWindowSize.md
+++ b/developer/engine/android/18.0/KMManager/getWindowSize.md
@@ -19,7 +19,11 @@ KMManager.getWindowSize(Context context)
 Returns the window size (native resolution) of the display as (int x, int y).
 
 ## Description
-Use this method to get the size of the entire display. It may or may not include [system decoration areas](https://developer.android.com/reference/android/view/Display)
+Use this method to get the size of the entire display. 
+
+For API level 29 and below, the size of the [entire display minus system decoration areas](https://developer.android.com/reference/android/view/Display#getSize(android.graphics.Point) is returned.
+
+For API level 30 and above, it may or may not include [system decoration areas](https://developer.android.com/reference/android/view/Display)
 
 ## Examples
 

--- a/developer/engine/android/18.0/KMManager/index.md
+++ b/developer/engine/android/18.0/KMManager/index.md
@@ -140,11 +140,20 @@ The KMManager is the core class which provides most of the methods and constants
 [`getMaySendCrashReport()`](getMaySendCrashReport)
 : returns whether Keyman Engine is allowed to send crash reports over the network to sentry.keyman.com
 
+[`getOrientation()`](getOrientation)
+: returns the device's current orientation (Portrait vs Landscape)
+
 [`getSpacebarText()`](getSpacebarText)
 : returns the current text display pattern for the spacebar
 
 [`getVersion()`](getVersion)
 : returns the version number of Keyman Engine
+
+[`getWindowDensity()`](getWindowDensity)
+: returns the density of the window
+
+[`getWindowSize()`](getWindowSize)
+: returns the size of an area the window would occupy
 
 [`hasConnection()`](hasConnection)
 : returns whether the device has active network connection


### PR DESCRIPTION
Follows #1268 and documents Keyman Engine for Android 18.0 API's added from keymanapp/keyman#11436

* getOrientation() (added in 17.0 on keymanapp/keyman#10442 )
* getWindowDensity()
* getWindowSize()

TODO. Document some more API's from previous releases
* lexicalModelExists()
