### PR TITLE
fix: should use published API for KMW option access

### DIFF
--- a/cdn/dev/js/kbd-docs.js
+++ b/cdn/dev/js/kbd-docs.js
@@ -75,7 +75,7 @@ function loaded(){
 
     var url = location.pathname.split('/');
     var keyboardName = url[url.length-3], keyboardVersion = url[url.length-2];
-    var keyboardPath = keyman.config.options['keyboards'] + keyboardName + '/' + keyboardVersion + '/' + keyboardName + '-' + keyboardVersion + '.js';
+    var keyboardPath = keyman.util.getOption('keyboards') + keyboardName + '/' + keyboardVersion + '/' + keyboardName + '-' + keyboardVersion + '.js';
 
     var fontFamily = null, fontSource = null;
 


### PR DESCRIPTION
Fixes https://github.com/keymanapp/keyman/issues/11466.
Reworks #1265.

Uses a pre-existing published API: https://help.keyman.com/developer/engine/web/17.0/reference/util/getOption