### PR TITLE
feat: include the version switcher in the errors page and show where the URL's subpath is located across the versions' folders

### DIFF
--- a/_includes/errors/404.php
+++ b/_includes/errors/404.php
@@ -4,7 +4,7 @@
   head([
     'title' => "Page not found",
     'index' => false,
-    'crumbs' => false,
+    'crumbs' => true,
   ]);
 
   $page = $_SERVER["REQUEST_URI"];
@@ -16,7 +16,7 @@
       $s = @htmlspecialchars($v, ENT_QUOTES, 'ISO-8859-1');
     return $s;
   }
-
+  
 ?>
 <h1>Page not found</h1>
 

--- a/_includes/includes/page-version.php
+++ b/_includes/includes/page-version.php
@@ -60,22 +60,18 @@
       }
 
       // Build the menu
-      echo "<div id='version-selector'>Other versions";
-      echo "<div>";
+      $html = "<div id='version-selector'>Other versions";
+      $html .= "<div>";
+
+      $found = false;
 
       foreach($PageVersion->versions as $version) {
-        $found = true;
         $folder = "{$_SERVER['DOCUMENT_ROOT']}{$PageVersion->basePath}/{$version}/";
         if(!file_exists("{$folder}{$file}.php") && !file_exists("{$folder}/{$file}.md")) {
-          // We don't have the same content in that version, so point to home page
-          if($version == $PageVersion->currentVersion) {
-            $text = "Version $version (home page, current version)";
-            $target = "{$PageVersion->basePath}/current-version/{$PageVersion->subPath}";
-          } else {
-              $text = "Version $version (home page)";
-              $target = "{$PageVersion->basePath}/$version/";
-            }
+          // Skip links to versions that don't have this exact page
+          continue;
         } else {
+          $found = true;
           if($version == $PageVersion->currentVersion) {
             $text = "Version $version (current version)";
             $target = "{$PageVersion->basePath}/current-version/{$PageVersion->subPath}";
@@ -85,16 +81,19 @@
           }
         }
 
-        if($version == $PageVersion->versionedPath && !$found) {
-          echo "<span>$text</span>";
+        if($version == $PageVersion->versionedPath) {
+          $html .= "<span>$text</span>";
         } else {
-          echo "<a href='$target'>$text</a>";
+          $html .= "<a href='$target'>$text</a>";
         }
       }
 
-      echo "</div></div>";
+      $html .= "</div></div>";
+      if($found) {
+        echo $html;
+      }
     }
-  
+
     ///
     /// Test that the url is in a versioned folder (only support products|developer at present)
     ///

--- a/_includes/includes/page-version.php
+++ b/_includes/includes/page-version.php
@@ -53,7 +53,7 @@
       global $PageVersion;
       if(!$PageVersion->active) return;
 
-      if($PageVersion->subPath == '' || $PageVersion->subPath[strlen($PageVersion->subPath)] == '/') {
+      if($PageVersion->subPath == '' || $PageVersion->subPath[strlen($PageVersion->subPath)-1] == '/') {
         $file = $PageVersion->subPath.'index';
       } else {
         $file = $PageVersion->subPath;
@@ -105,7 +105,7 @@
         $subPath = $matches[4];
         return true;
       }
-        return false;
+      return false;
     }
 
     ///

--- a/_includes/includes/page-version.php
+++ b/_includes/includes/page-version.php
@@ -18,9 +18,9 @@
         if(sizeof($this->versions) == 0) {
           $this->active = false;
         } else {
-          $this->currentVersion = $this::getCurrentVersion($this->versions);
-          if($this->versionedPath == 'current-version') $this->versionedPath = $this->currentVersion;
-          if($this->versionedPath == 'latest-version') $this->versionedPath = $this->versions[0];
+            $this->currentVersion = $this::getCurrentVersion($this->versions);
+            if($this->versionedPath == 'current-version') $this->versionedPath = $this->currentVersion;
+            if($this->versionedPath == 'latest-version') $this->versionedPath = $this->versions[0];
         }
       }
     }
@@ -53,7 +53,7 @@
       global $PageVersion;
       if(!$PageVersion->active) return;
 
-      if($PageVersion->subPath == '' || $PageVersion->subPath[strlen($PageVersion->subPath)-1] == '/') {
+      if($PageVersion->subPath == '' || $PageVersion->subPath[strlen($PageVersion->subPath)] == '/') {
         $file = $PageVersion->subPath.'index';
       } else {
         $file = $PageVersion->subPath;
@@ -64,16 +64,17 @@
       echo "<div>";
 
       foreach($PageVersion->versions as $version) {
+        $found = true;
         $folder = "{$_SERVER['DOCUMENT_ROOT']}{$PageVersion->basePath}/{$version}/";
         if(!file_exists("{$folder}{$file}.php") && !file_exists("{$folder}/{$file}.md")) {
           // We don't have the same content in that version, so point to home page
           if($version == $PageVersion->currentVersion) {
             $text = "Version $version (home page, current version)";
-            $target = "{$PageVersion->basePath}/current-version/";
+            $target = "{$PageVersion->basePath}/current-version/{$PageVersion->subPath}";
           } else {
-            $text = "Version $version (home page)";
-            $target = "{$PageVersion->basePath}/$version/";
-          }
+              $text = "Version $version (home page)";
+              $target = "{$PageVersion->basePath}/$version/";
+            }
         } else {
           if($version == $PageVersion->currentVersion) {
             $text = "Version $version (current version)";
@@ -84,7 +85,7 @@
           }
         }
 
-        if($version == $PageVersion->versionedPath) {
+        if($version == $PageVersion->versionedPath && !$found) {
           echo "<span>$text</span>";
         } else {
           echo "<a href='$target'>$text</a>";
@@ -93,7 +94,7 @@
 
       echo "</div></div>";
     }
-
+  
     ///
     /// Test that the url is in a versioned folder (only support products|developer at present)
     ///
@@ -104,7 +105,7 @@
         $subPath = $matches[4];
         return true;
       }
-      return false;
+        return false;
     }
 
     ///
@@ -120,7 +121,7 @@
 
       usort($versions, 'version_compare_reverse');
 
-      return $versions;
+      return $versions; // versions [18.0,17.0,16.0,...,1.0]
     }
 
     ///
@@ -137,7 +138,6 @@
           in_array($matches[1], $versions)) {
         $currentVersion = $matches[1];
       }
-
       return $currentVersion;
     }
   }


### PR DESCRIPTION
Fixes: #1058

Case 1:
![image](https://github.com/keymanapp/help.keyman.com/assets/90595388/9681720d-0e94-4a57-98c3-9664c66f3500)

Case 2:
![image](https://github.com/keymanapp/help.keyman.com/assets/90595388/6e9e499c-7188-4598-b566-dc1f8d190616)

The content can only be found if the URL is using the structure: basePath + versionedPath + subPath. If found, the version switcher will show as the Version. If not, it will direct you to the home page. 

Please kindly review.