### PR TITLE
chore: cleanup definition lists and styling

### DIFF
--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -926,10 +926,6 @@ input[type="search"] {
   margin-right: 9px;
 }
 
-/*#section2 pre[class*="language-"] code[class*="language-"] {
-  line-height: 1.4;
-}*/
-
 #section2 p > code[class*="language-"],
 #section2 li > code[class*="language-"],
 #section2 dt > code[class*="language-"],

--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -924,16 +924,24 @@ input[type="search"] {
 #section2 pre[class*="language-"] {
   margin-left: 9px;
   margin-right: 9px;
-  padding: 9px;
-  line-height: 1.4;
 }
 
-#section2 pre[class*="language-"] code[class*="language-"] {
+/*#section2 pre[class*="language-"] code[class*="language-"] {
   line-height: 1.4;
-}
+}*/
 
-#section2 code[class*="language-"] {
+#section2 p > code[class*="language-"],
+#section2 li > code[class*="language-"],
+#section2 dt > code[class*="language-"],
+#section2 dd > code[class*="language-"] {
 	font-size: 10.5pt
+}
+
+#section2 h1 > code[class*="language-"],
+#section2 h2 > code[class*="language-"],
+#section2 h3 > code[class*="language-"],
+#section2 h4 > code[class*="language-"] {
+	background: none;
 }
 
 .product-index {

--- a/developer/17.0/context/new-ldml-project-parameters.md
+++ b/developer/17.0/context/new-ldml-project-parameters.md
@@ -10,25 +10,30 @@ Projects can also be created from the command line with [KMConvert](kmconvert).
 
 ### Parameters
 
-* Keyboard Name
+Keyboard Name
+
 : **Required.** The descriptive name of the keyboard. This will be set in the
   `<info name` attribute value in the keyboard, in the
   package name, and where appropriate in documentation and metadata.
 
-* Description
+Description
+
 : **Required.** A short description of the purpose of the keyboard. This will
   show up in a keyboard search on keyman.com and supports basic Markdown (no
   embedded HTML). This is stored in the package metadata.
 
-* Author
+Author
+
 : Optional. The name of the developer of the keyboard. This will be set in
   the package metadata, and where appropriate in documentation and metadata.
 
-* Copyright, Full Copyright
+Copyright, Full Copyright
+
 : Optional. A copyright string for the keyboard. This will be set in the
   package metadata, and where appropriate in documentation and metadata.
 
-* Version
+Version
+
 : **Required.** The initial version number of the keyboard. For an LDML keyboard
   this can be a [SEMVER](https://semver.org) compatible version number, but note
   that Keyman as of version 17 is more restrictive and still requires the
@@ -37,19 +42,22 @@ Projects can also be created from the command line with [KMConvert](kmconvert).
   be set also in the package metadata, and where appropriate in documentation
   and metadata.
 
-* Supported Languages
+Supported Languages
+
 : **Required.** Specifies the default BCP 47 language tags which will be added
   to the package data and project metadata. (Required) While the LDML keyboard
   specification allows for complete BCP 47 tags, in Keyman, these are currently
   restricted to use of the Language, Script, and Region subtags.
 
-* Path
+Path
+
 : **Required.** Specifies the base path where the project folder will be
   created. The project folder name will be the keyboard ID. If the folder
   already exists, then you will be prompted before Keyman Developer overwrites
   files inside it.
 
-* Keyboard ID
+Keyboard ID
+
 : **Required.** The base filename of the keyboard, project and package. This
   must conform to the Keyman keyboard identifier rules, using the characters
   a-z, 0-9 and _ (underscore) only.

--- a/developer/17.0/context/package-editor.md
+++ b/developer/17.0/context/package-editor.md
@@ -26,16 +26,20 @@ The Keyboards tab shows you some status information of keyboards you've added to
 the package. There are also optional font dropdowns and a required "Languages"
 section. The fields on the tab are:
 
-* **Description**
+**Description**
+
 : The keyboard name (`&name` system store).
 
-* **Files**
+**Files**
+
 : This shows the associated keyboard files (.kmx and .js files)
 
-* **Version**
+**Version**
+
 : The keyboard version (`&keyboardversion` system store).
 
-* **Is right-to-left**
+**Is right-to-left**
+
 : Currently, this is only applicable to Android, iOS and Web (that is, .js
   format) keyboards. This reflects the checkbox in the [Details tab](./keyboard-editor#details-fields) of the Keyboard editor.
 
@@ -44,22 +48,26 @@ section. The fields on the tab are:
   * "Keyboard is right-to-left" is checked in the Keyboard editor
   * The compiled .js keyboard is added to the package
 
-* **Keyboard font**
+**Keyboard font**
+
 : When font files are added to the package, this dropdown tells the Keyman apps
   which font to use when rendering the On Screen Keyboard touch keyboard.
   Optional.
 
-* **Display font**
+**Display font**
+
 : When font files are added to the package, this dropdown tells the Keyman apps
   for iOS and Android which font to use in edit fields. It only applies within
   the Keyman app and apps that support this functionality. Optional.
 
-* **Web fonts**
+**Web fonts**
+
 : It is possible now to specify additional font filenames that will be made
   available to KeymanWeb, for example, providing fonts in WOFF or WOFF2 formats.
   [More on web fonts](select-web-fonts)
 
-* **Languages**
+**Languages**
+
 : Because the language information in the .kmn source is deprecated, the
   "Languages" section is required. Each language listed here is a [BCP 47 language tag](../reference/bcp-47). Use the **Add** button to
   bring up the "Select BCP 47 Tag" dialog. When Keyman installs the keyboard
@@ -68,7 +76,8 @@ section. The fields on the tab are:
 
   ![Package Editor - Select BCP 47 Tag dialog](/cdn/dev/img/developer/170/ui/frmPackageEditor_Select_BCP_47_Tag.png)
 
-* **Examples**
+**Examples**
+
 : Examples allow you to provide short keystroke sequences to type sample text
   with your keyboard. This can be the easiest way for a new user to start using
   your keyboard, and is particularly helpful when your keyboard makes use of
@@ -140,7 +149,7 @@ There are two types of package relationships:
 * Related: if the 'Deprecated' check box is not selected, then this the
   relationship information is used to provide links to the related packages on
   the Keyman website. For example, you may create two keyboards for the same
-  language with different keying orders; then it would be appropriate to 
+  language with different keying orders; then it would be appropriate to
   cross-reference them with this field.
 
 ![Package Editor - Edit Related Packages dialog](/cdn/dev/img/developer/170/ui/frmPackageEditor_EditRelatedPackage.png)

--- a/developer/17.0/context/server.md
+++ b/developer/17.0/context/server.md
@@ -346,12 +346,12 @@ Keyman Developer's **Tools** menu, with three items:
 : Opens the public URL to your current Keyman Developer Server instance in the
   default browser on your computer.
 
-* **Copy URL to clipboard**
+**Copy URL to clipboard**
 
 : Copies the public URL to the clipboard so you can share it via email, instant
   message, or other medium.
 
-* **Configure...**
+**Configure...**
 
 : Opens the Keyman Developer Server Options dialog box.
 

--- a/developer/17.0/reference/kmc/cli/reference.md
+++ b/developer/17.0/reference/kmc/cli/reference.md
@@ -22,9 +22,9 @@ kmc [replaces kmcomp](kmcomp-migration) from earlier versions of Keyman Develope
 
 The following parameters are available:
 
-## kmc commands
+## `kmc` commands
 
-* `kmc build [infile...]`, `kmc build file [infile...]`
+`kmc build [infile...]`, `kmc build file [infile...]`
 
 : Compile one or more Keyman files. Takes Keyman keyboard source files, and
   compiles them into the binary formats used by the Keyman apps. Supports
@@ -42,39 +42,39 @@ The following parameters are available:
   File lists can be referenced with @filelist.txt. If no input file is supplied,
   kmc will attempt to build a project file in the current folder.
 
-* `kmc build ldml-test-data`
+`kmc build ldml-test-data`
 
 : Converts LDML keyboard test .xml file to .json.
 
-* `kmc build windows-package-installer`
+`kmc build windows-package-installer`
 
 : Builds a .exe installer for a keyboard, together with the Keyman installer,
   for Windows only.
 
-* `kmc analyze osk-char-use [infile...]`
+`kmc analyze osk-char-use [infile...]`
 
 : Analyze on screen keyboard files for character usage
 
-* `kmc analyze osk-rewrite-from-char-use -m mapping-file [infile...]`
+`kmc analyze osk-rewrite-from-char-use -m mapping-file [infile...]`
 
 : Rewrites On Screen Keyboard files from source mapping
 
-* `kmc message [message...]`
+`kmc message [message...]`
 
 : Describes one or more compiler messages in greater detail
 
 ## `kmc` global options
 
-* `-h`, `--help`
+`-h`, `--help`
 
 : Display help on kmc; note that `kmc --help` can be used for further detail on
   subcommands, e.g. `kmc build --help`
 
-* `-V`, `--version`
+`-V`, `--version`
 
 : Prints the version number of kmc
 
-* `--no-error-reporting`, `--error-reporting`
+`--no-error-reporting`, `--error-reporting`
 
 : Enable or disable error reporting to keyman.com, overriding [user
   settings](../../user-settings). Error reporting is for fatal errors in the
@@ -82,7 +82,7 @@ The following parameters are available:
   reports, although some filenames and paths may be present in the diagnostic
   data attached to the report.
 
-* `-l <logLevel>`, `--log-level <logLevel>`
+`-l <logLevel>`, `--log-level <logLevel>`
 
 : Controls the level of logging to console for messages relating to the
   compilation process. The options are:
@@ -102,21 +102,21 @@ The following parameters are available:
 
 ## `kmc build` options
 
-* `--color`, `--no-color`
+`--color`, `--no-color`
 
 : Controls colorization for log messages, using ANSI color controls. If both of
   these settings are omitted, kmc will attempt to detect from console, and will
   use colorization for interactive terminals, and no colorization when
   redirection is being used.
 
-* `-d`, `--debug`
+`-d`, `--debug`
 
 : Include debug information in output files. Debug information is used for
   interactive debugging of .kmx files within the Keyman Developer IDE. This
   flag also produces pretty printed .js files for web keyboards, making
   interactive debugging of web keyboards simpler.
 
-* `-w`, `--compiler-warnings-as-errors` vs `-W`, `--no-compiler-warnings-as-errors`
+`-w`, `--compiler-warnings-as-errors` vs `-W`, `--no-compiler-warnings-as-errors`
 
 : Controls whether or not warnings fail the build; overrides project-level
   warnings-as-errors option. Most compiler warnings are an indication that
@@ -124,7 +124,7 @@ The following parameters are available:
   produce a result. This strict compilation mode helps to ensure that problems
   are caught early, and is recommended.
 
-* `-m <number>`, `--message <number>`
+`-m <number>`, `--message <number>`
 
 : Adjusts the severity of info, hint or warning messages. Error and fatal error
   messages can not be adjusted. Message severity can be adjusted to:
@@ -140,18 +140,18 @@ The following parameters are available:
   This option may be repeated to adjust multiple messages. The `-m` option must
   be specified each time.
 
-* `--no-compiler-version`
+`--no-compiler-version`
 
 : Excludes compiler version metadata from output. This is helpful for producing
   files that will be identical regardless of the compiler version, for
   regression testing.
 
-* `--no-warn-deprecated-code`
+`--no-warn-deprecated-code`
 
 : Turns off warnings (CWARN_HeaderStatementIsDeprecated,
   CWARN_LanguageHeadersDeprecatedInKeyman10) for deprecated code styles
 
-* `--log-format <logFormat>`
+`--log-format <logFormat>`
 
 : Output log format. The available options are:
   * `formatted` (default): emits log messages in a human-readable format
@@ -163,7 +163,7 @@ The following parameters are available:
     * code
     * message
 
-* `-o <filename>`, `--out-file <filename>`
+`-o <filename>`, `--out-file <filename>`
 
 : Overrides the default path and filename for the output file(s). Note that
   some compilers emit multiple files, in which case, the output filenames
@@ -171,7 +171,7 @@ The following parameters are available:
 
 ## `kmc build file` additional options
 
-* `--for-publishing`
+`--for-publishing`
 
 : Verifies that project meets @keymanapp repository requirements. This also
   causes a .keyboard-info or .model-info file to be emitted when compiling the
@@ -208,46 +208,48 @@ already be compiled.
 
 ## `kmc build windows-package-installer` additional options
 
-* `--msi <msiFilename>`
+`--msi <msiFilename>`
 
 : Full path of keymandesktop.msi to bundle into the installer. This file can be
   downloaded from https://downloads.keyman.com/windows/stable (/version).
 
-* `--exe <exeFilename>`
+`--exe <exeFilename>`
 
 : Location of setup.exe. This file can be downloaded from
   https://downloads.keyman.com/windows/stable (/version).
 
-* `--license <licenseFilename>`
+`--license <licenseFilename>`
 
 : Location of license.txt for Keyman for Windows.
 
-* `--title-image [titleImageFilename]`
+`--title-image [titleImageFilename]`
 
 : Location of title image file. This should be a .png, .jpg, or .bmp file which
   replaces the standard 'Keyman for Windows' image in the bootstrap installer.
 
-* `--app-name [applicationName]`
+`--app-name [applicationName]`
 
 : Installer property: name of the application to be installed (default: "Keyman")
 
-* `--start-disabled`
+`--start-disabled`
 
 : Installer property: do not enable keyboards after installation completes
 
-* `--start-with-configuration`
+`--start-with-configuration`
 
 : Installer property: start Keyman Configuration after installation completes
 
 ### Examples
 
-* Windows (command prompt):
+#### Windows, command prompt (all one line)
 
 ```bat
-kmc build windows-package-installer .\khmer_angkor.kps --msi "C:\Program Files (x86)\Common Files\Keyman\Cached Installer Files\keymandesktop.msi" --exe .\setup-redist.exe --license .\LICENSE.md --out-file .\khmer.exe
+kmc build windows-package-installer .\khmer_angkor.kps
+  --msi "C:\Program Files (x86)\Common Files\Keyman\Cached Installer Files\keymandesktop.msi"
+  --exe .\setup-redist.exe --license .\LICENSE.md --out-file .\khmer.exe
 ```
 
-* Bash (Linux, WSL, macOS, etc):
+#### Bash (Linux, WSL, macOS, etc)
 
 ```shell
 kmc build windows-package-installer \
@@ -262,19 +264,19 @@ Note: paths shown above may vary.
 
 ## `kmc analyze osk-char-use` options
 
-* `-b, --base`
+`-b, --base`
 
 : First PUA codepoint to use, in hexadecimal (default F100)
 
-* `--include-counts`
+`--include-counts`
 
 : Include number of times each character is referenced (default: false)
 
-* `--strip-dotted-circle`
+`--strip-dotted-circle`
 
 : Strip U+25CC (dotted circle base) from results (default: false)
 
-* `-m, --mapping-file <filename>`
+`-m, --mapping-file <filename>`
 
 : Result file to write to (.json, .md, or .txt)
 
@@ -284,7 +286,7 @@ For more information on the purpose of `analyze osk-char-use` and
 
 ## `kmc analyze osk-rewrite-from-char-use` options
 
-* `-m, --mapping-file <filename>`
+`-m, --mapping-file <filename>`
 
 : JSON mapping file to read from.
 
@@ -304,19 +306,19 @@ messages can be specified on the command line, with one file per message, and
 index files also generated. The Markdown mode is used to generate the online
 documentation on help.keyman.com.
 
-* `-f, --format <format>`
+`-f, --format <format>`
 
 : Output format, one of:
   * `text`: plain text output to console or file, of specified messages
   * `json`: JSON formatted to console or file, of specified messages
   * `markdown`: Markdown formatted text output, to a folder, of all messages
 
-* `-o, --out-path <out-path>`
+`-o, --out-path <out-path>`
 
 : Output folder name for Markdown format (required for Markdown), or optional
   output filename for text and json formats.
 
-* `-a, --all-messages`
+`-a, --all-messages`
 
 : Emit descriptions for all messages (text, json formats)
 

--- a/developer/17.0/reference/user-settings.md
+++ b/developer/17.0/reference/user-settings.md
@@ -4,8 +4,7 @@ title: Keyman Developer User Settings
 
 Keyman Developer has settings stored in several locations:
 
-* `~/.keymandeveloper/options.json`
-  (`%userprofile%\.keymandeveloper\options.json` on Windows)
+`~/.keymandeveloper/options.json` (`%userprofile%\.keymandeveloper\options.json` on Windows)
 
 : User preferences are stored in this file. In version 16 and earlier, these
   options were stored in the Registry under
@@ -13,17 +12,17 @@ Keyman Developer has settings stored in several locations:
   the Registry will be migrated to the `options.json` file on first start
   of the Keyman Developer IDE.
 
-* `HKCU\Software\Keyman\Keyman Developer\IDE`
+`HKCU\Software\Keyman\Keyman Developer\IDE`
 
 : Stores settings specific to the IDE, including window locations and
   visibility, recently used projects, font preferences.
 
-* `%appdata%\Keyman\Keyman Developer`
+`%appdata%\Keyman\Keyman Developer`
 
 : Stores files related to the runtime environment of Keyman Developer, including
   cache files.
 
-* `%localappdata%\Keyman\Diag`
+`%localappdata%\Keyman\Diag`
 
 : Stores files relating to diagnostics for Keyman Developer; this folder is also
   used for Keyman for Windows diagnostics.

--- a/developer/cloud/model/1.0/index.md
+++ b/developer/cloud/model/1.0/index.md
@@ -8,7 +8,8 @@ Documents the [`api.keyman.com/model/<model_id>`](https://api.keyman.com/model) 
 
 ### Parameters
 
-* `model_id`
+`model_id`
+
 : The identifier of the model to return
 
 ### Results
@@ -75,5 +76,6 @@ A valid response will return an array of matching
 
 ### Version History
 
-* 1.0, 2018-01-01
+1.0, 2018-01-01
+
 : Initial version

--- a/developer/cloud/model/index.md
+++ b/developer/cloud/model/index.md
@@ -2,5 +2,6 @@
 title: Model result API
 ---
 
-* [Model result API 1.0 Specification](1.0)
+[Model result API 1.0 Specification](1.0)
+
 : API to lookup a single lexical model available for Keyman

--- a/developer/cloud/version/2.0/index.md
+++ b/developer/cloud/version/2.0/index.md
@@ -27,10 +27,12 @@ https://api.keyman.com/version/$platform/$level
 
 ### Parameters
 
-* `platform`
+`platform`
+
 : The platform to query against. Possible values are: `android`, `ios`, `linux`, `mac`, `web` or `windows`.
 
-* `level` <span class="optional">(optional)</span>
+`level` <span class="optional">(optional)</span>
+
 : The stability level to query, default `stable`. Possible values are: `stable`, `beta`, `alpha` or `all`.
 
 If `platform` is not passed, then the API falls back to version 1.0.

--- a/developer/engine/web/15.0/reference/keyboard_properties.md
+++ b/developer/engine/web/15.0/reference/keyboard_properties.md
@@ -12,55 +12,72 @@ may need to interact with custom developed keyboards if, for example, they use a
 Each registered keyboard object defines some or all of the following exposed
 string properties:
 
-* `KN`
+`KN`
+
 : `string`, (`name`) visible name of the keyboard, required.
 
-* `KI`
+`KI`
+
 : `string`, (`internalName`) identifier of the keyboard, starting with `Keyboard_`, required.
 
-* `KMINVER`
+`KMINVER`
+
 : `string`, minimum version that the keyboard will run on, `2.0` if not present, optional.
 
-* `KV`
+`KV`
+
 : `object`, on screen keyboard definition, optional.
 
-* `KDU`
+`KDU`
+
 : `number`, `1` to display underlying characters on On Screen Keyboard, `0` or omitted to hide them, optional
 
-* `KH`
+`KH`
+
 : `string`, Keyboard help, in HTML; if present replaces `KV` in the On Screen Keyboard, optional
 
-* `KM`
+`KM`
+
 : `number`, `1` to use mnemonic layout, `0` or omitted for positional, optional
 
-* `KBVER`
+`KBVER`
+
 : `string`, version of the keyboard (should be dotted decimal format), optional
 
-* `KMBM`
+`KMBM`
+
 : `number`, bitmask denoting modifiers used in the keyboard, if not present defaults to 0x0070, optional
 
-* `KVKL`
+`KVKL`
+
 : `object`, touch layout definition, optional.
 
-* `KVER`
+`KVER`
+
 : `string`, version of Keyman Developer used to compile the keyboard, optional
 
-* `KVS`
+`KVS`
+
 : `string[]`, array of all variable store names found in the keyboard (15.0 and later), optional
 
-* `KS`
+`KS`
+
 : `number`, `1` means Unicode characters U+10000-U+10FFFF, including the Supplementary Multilingual Plane (SMP), are used in the keyboard, optional
 
-* `KVKD`
+`KVKD`
+
 : `object`, Virtual key dictionary listing custom touch keys used in the keyboard, optional
 
-* `KCSS`
+`KCSS`
+
 : `string`, Custom CSS defined by the keyboard, optional
 
-* `KFont`
+`KFont`
+
 : `object`, Embedded font specification for mapped input elements and on-screen keyboard, optional
 
-* `KOskFont`
+`KOskFont`
+
 : `object`, Embedded font specification for on-screen keyboard, optional
 
 For most keyboards which require an embedded font, the same font will be used
@@ -71,8 +88,10 @@ keyboard.
 
 The `KFont` and `KOskFont` members are objects with the following members:
 
-* `family`
+`family`
+
 : `string`, font-family name for embedded font, e.g. `'LatinWeb'`
 
-* `files`
+`files`
+
 : `string` or `string[]`, Font file name or names, e.g. `['DejaVuSans.ttf','DejaVuSans.woff','DejaVuSans.eot']`

--- a/developer/engine/web/16.0/reference/keyboard_properties.md
+++ b/developer/engine/web/16.0/reference/keyboard_properties.md
@@ -12,55 +12,72 @@ may need to interact with custom developed keyboards if, for example, they use a
 Each registered keyboard object defines some or all of the following exposed
 string properties:
 
-* `KN`
+`KN`
+
 : `string`, (`name`) visible name of the keyboard, required.
 
-* `KI`
+`KI`
+
 : `string`, (`internalName`) identifier of the keyboard, starting with `Keyboard_`, required.
 
-* `KMINVER`
+`KMINVER`
+
 : `string`, minimum version that the keyboard will run on, `2.0` if not present, optional.
 
-* `KV`
+`KV`
+
 : `object`, on screen keyboard definition, optional.
 
-* `KDU`
+`KDU`
+
 : `number`, `1` to display underlying characters on On Screen Keyboard, `0` or omitted to hide them, optional
 
-* `KH`
+`KH`
+
 : `string`, Keyboard help, in HTML; if present replaces `KV` in the On Screen Keyboard, optional
 
-* `KM`
+`KM`
+
 : `number`, `1` to use mnemonic layout, `0` or omitted for positional, optional
 
-* `KBVER`
+`KBVER`
+
 : `string`, version of the keyboard (should be dotted decimal format), optional
 
-* `KMBM`
+`KMBM`
+
 : `number`, bitmask denoting modifiers used in the keyboard, if not present defaults to 0x0070, optional
 
-* `KVKL`
+`KVKL`
+
 : `object`, touch layout definition, optional.
 
-* `KVER`
+`KVER`
+
 : `string`, version of Keyman Developer used to compile the keyboard, optional
 
-* `KVS`
+`KVS`
+
 : `string[]`, array of all variable store names found in the keyboard (15.0 and later), optional
 
-* `KS`
+`KS`
+
 : `number`, `1` means Unicode characters U+10000-U+10FFFF, including the Supplementary Multilingual Plane (SMP), are used in the keyboard, optional
 
-* `KVKD`
+`KVKD`
+
 : `object`, Virtual key dictionary listing custom touch keys used in the keyboard, optional
 
-* `KCSS`
+`KCSS`
+
 : `string`, Custom CSS defined by the keyboard, optional
 
-* `KFont`
+`KFont`
+
 : `object`, Embedded font specification for mapped input elements and on-screen keyboard, optional
 
-* `KOskFont`
+`KOskFont`
+
 : `object`, Embedded font specification for on-screen keyboard, optional
 
 For most keyboards which require an embedded font, the same font will be used
@@ -71,8 +88,10 @@ keyboard.
 
 The `KFont` and `KOskFont` members are objects with the following members:
 
-* `family`
+`family`
+
 : `string`, font-family name for embedded font, e.g. `'LatinWeb'`
 
-* `files`
+`files`
+
 : `string` or `string[]`, Font file name or names, e.g. `['DejaVuSans.ttf','DejaVuSans.woff','DejaVuSans.eot']`

--- a/developer/engine/web/17.0/reference/keyboard_properties.md
+++ b/developer/engine/web/17.0/reference/keyboard_properties.md
@@ -12,55 +12,72 @@ may need to interact with custom developed keyboards if, for example, they use a
 Each registered keyboard object defines some or all of the following exposed
 string properties:
 
-* `KN`
+`KN`
+
 : `string`, (`name`) visible name of the keyboard, required.
 
-* `KI`
+`KI`
+
 : `string`, (`internalName`) identifier of the keyboard, starting with `Keyboard_`, required.
 
-* `KMINVER`
+`KMINVER`
+
 : `string`, minimum version that the keyboard will run on, `2.0` if not present, optional.
 
-* `KV`
+`KV`
+
 : `object`, on screen keyboard definition, optional.
 
-* `KDU`
+`KDU`
+
 : `number`, `1` to display underlying characters on On Screen Keyboard, `0` or omitted to hide them, optional
 
-* `KH`
+`KH`
+
 : `string`, Keyboard help, in HTML; if present replaces `KV` in the On Screen Keyboard, optional
 
-* `KM`
+`KM`
+
 : `number`, `1` to use mnemonic layout, `0` or omitted for positional, optional
 
-* `KBVER`
+`KBVER`
+
 : `string`, version of the keyboard (should be dotted decimal format), optional
 
-* `KMBM`
+`KMBM`
+
 : `number`, bitmask denoting modifiers used in the keyboard, if not present defaults to 0x0070, optional
 
-* `KVKL`
+`KVKL`
+
 : `object`, touch layout definition, optional.
 
-* `KVER`
+`KVER`
+
 : `string`, version of Keyman Developer used to compile the keyboard, optional
 
-* `KVS`
+`KVS`
+
 : `string[]`, array of all variable store names found in the keyboard (15.0 and later), optional
 
-* `KS`
+`KS`
+
 : `number`, `1` means Unicode characters U+10000-U+10FFFF, including the Supplementary Multilingual Plane (SMP), are used in the keyboard, optional
 
-* `KVKD`
+`KVKD`
+
 : `object`, Virtual key dictionary listing custom touch keys used in the keyboard, optional
 
-* `KCSS`
+`KCSS`
+
 : `string`, Custom CSS defined by the keyboard, optional
 
-* `KFont`
+`KFont`
+
 : `object`, Embedded font specification for mapped input elements and on-screen keyboard, optional
 
-* `KOskFont`
+`KOskFont`
+
 : `object`, Embedded font specification for on-screen keyboard, optional
 
 For most keyboards which require an embedded font, the same font will be used
@@ -71,8 +88,10 @@ keyboard.
 
 The `KFont` and `KOskFont` members are objects with the following members:
 
-* `family`
+`family`
+
 : `string`, font-family name for embedded font, e.g. `'LatinWeb'`
 
-* `files`
+`files`
+
 : `string` or `string[]`, Font file name or names, e.g. `['DejaVuSans.ttf','DejaVuSans.woff','DejaVuSans.eot']`

--- a/developer/language/reference/baselayout.md
+++ b/developer/language/reference/baselayout.md
@@ -16,7 +16,8 @@ if(&baselayout = layoutName) ... > ...
 
 ### Parameters
 
-* `layoutName`
+`layoutName`
+
 : The name or identifier of the layout to compare against. This should be an ISO
 639 Language Name and ISO3166 Country Code pair, separated by `-` (hyphen), e.g.
 `"en-US"`, or it can be the name of a Windows keyboard DLL, e.g. `"kbdus.dll"`.


### PR DESCRIPTION
* removes dot point so definition lists render correctly in kmc reference
* tweaks styling for code blocks in headings - background, font size

## Before
![image](https://github.com/keymanapp/help.keyman.com/assets/4498365/d9beeaf5-f72b-4850-ade5-a4f5628f44a6)

## After
![image](https://github.com/keymanapp/help.keyman.com/assets/4498365/0c7bd084-b728-42d4-8f98-f7c6b8b36e8e)
