### PR TITLE
Add information on shared fonts

### DIFF
--- a/developer/keyboards/github/step-0.md
+++ b/developer/keyboards/github/step-0.md
@@ -65,12 +65,15 @@ The folder structure for each keyboard has the following components:
  : contains `welcome.htm` and any resources it references. These files are included with the keyboard to provide local help for the keyboard.
 
 `xyz\xyz.kpj`
- : the Keyman Developer project file for the keyboard
+ : the Keyman Developer project file for the keyboard.
 This file must have the same base name as the folder/keyboard.
+As of June 2024, this file uses the format which Keyman Developer version 17 creates.
 Do not include the `xyz.kpj.user` file in the repository.
 
 `xyz\README.md`
  : description of the keyboard, target languages, target devices, author, etc.
+We recommend omitting any reference to the current version number so that this file doesn't need to be edited when the keyboard is updated.
+Similarly, we recommend omitting the date from the copyright statement, or just omitting the whole copyright statement.
 
 `xyz\HISTORY.md`
  : list of major changes to the keyboard (repository commits cover details)

--- a/developer/keyboards/github/step-0.md
+++ b/developer/keyboards/github/step-0.md
@@ -66,8 +66,6 @@ The folder structure for each keyboard has the following components:
 
 `xyz\xyz.kpj`
  : the Keyman Developer project file for the keyboard
-The `xyz.kpj` project file will contain references to the `xyz.kmn` and `xyz.kps` files.
-It must set the output path to `$PROJECTPATH\build`.
 This file must have the same base name as the folder/keyboard.
 Do not include the `xyz.kpj.user` file in the repository.
 
@@ -87,20 +85,14 @@ Do not include the `xyz.kpj.user` file in the repository.
    the keyboard are required.
 
 
-`xyz\xyz.keyboard_info`
- : a [metadata file](../../cloud/keyboard_info) detailing the keyboard's origin, version, requirements, and capabilities
-This file is used in the process of making your keyboard readily available for public download.
-Please see the [.keyboard_info section](../../cloud/keyboard_info) for more details.
-
 ## Copy Template Files
 
 If you used "Project", "New Project", "Basic" as mentioned above,
 Keyman Developer will have created files in your keyboard project folder similar to those mentioned in the next paragraph,
 so you can skip this step because you won't need to copy them.
 
-The **keyboards** repo contains a set of `.md` and `.keyboard_info` files you can copy and fill with details relevant to your keyboard.
+The **keyboards** repo contains a set of `.md` files you can copy and fill with details relevant to your keyboard.
 They're available at the `release/template/` folder.
-Remember to rename `template.keyboard_info` with your keyboard name (`xyz.keyboard_info` in the above example) after you copy it.
 The `.md` files use [Markdown](https://daringfireball.net/projects/markdown/),
 an easy-to-read plain text format that can be converted to HTML.
 

--- a/developer/keyboards/github/step-2.md
+++ b/developer/keyboards/github/step-2.md
@@ -12,7 +12,7 @@ When it is time to submit the keyboard on GitHub, you will need to place it in a
 specific folder. For the example "sample1", it would need to go into a "release/s" folder,
 so that the result is "release/s/sample1". Or if you want to use the "experimental"
 section of the repository, you'll aim for the "experimental/s" folder. 
-**Note:** Don't do this yet -- you'll drag files to GitHub in the step 3!
+**Note:** Don't do this yet -- you'll drag files to GitHub in step 3!
 
 But suppose your keyboard folder starts with a letter that doesn't appear? 
 In that case, you'll need to create a folder called "s" which contains the "sample1" folder. 
@@ -45,6 +45,7 @@ but remember that when you reference any built files within the package, make su
 
 Font and documentation files
  : Any files you reference in the package source .kps file, such as fonts, documentation, should be included in the `source` folder.
+ For more information on including fonts with your keyboard, see [Including fonts in your keyboard package](#including-fonts-in-your-keyboard-package) below.
 
 ## Do not include these files
 
@@ -65,3 +66,26 @@ The following files should **not** be included in the `source` folder because th
 Once you're done creating and testing your keyboard, you're ready to share the keyboard with us.
 
 [Step 3: Submitting a GitHub Pull Request](step-3 "Step 3: Submitting a GitHub Pull Request")
+
+## Including fonts in your keyboard package
+
+It is possible to include one or more font files in your keyboard package. When installing the keyboard, Keyman also installs the fonts from the package.
+
+If the font is unique to your keyboard, then the files for the font can be included in the "source" folder under your keyboard project folder and included in the keyboard package. (Note that any fonts included in the Keyman keyboards repository need to be licensed so that they can be freely redistributed. We recommend the Open Font License, https://openfontlicense.org)
+
+However, a number of fonts, which are used by multiple keyboards, have been placed in subfolders under a "shared" folder. The Keyman developers can update the fonts in one place and all the keyboards that use those fonts will benefit. If you desire to include one of these shared fonts in your keyboard, we prefer that you access the existing shared font files, rather than include another copy with your keyboard.
+
+If you have the entire repository on your local computer, as is the case for those using the "Advanced" directions, you already have all the shared fonts and you can just access them by navigating to them. But how can you access the shared fonts if you are using the "GitHub" directions?
+
+The answer is to create the portion of the shared folder structure that contains the fonts you need. You'll then be able to reference these files when creating your keyboard package and have the correct path.
+
+Take the example of the "ausephon" keyboard which includes the Charis SIL font files from the shared folder. This would mean creating a folder structure on your computer with:
+
+release/a/ausephon - where the "ausephon" folder contains the files for the "ausephon" keyboard 
+release/shared/fonts/sil/charis - where the "charis" folder contains the files for Charis SIL (from https://github.com/keymanapp/keyboards/tree/master/release/shared/fonts/sil/charis)
+
+The purpose of all this is to get the proper path when referencing these "shared" font files from the keyboard package. You won't be including any of the shared font files in your keyboard submission, but the paths to the fonts will be correct because you created the same folder structure used in Keyman's keyboards repository.
+
+When specifying the font files for the keyboard package (on the Packaging tab in Keyman Developer), navigate to the correct subfolder under the "shared" folder ("charis" in this example), so that the package source (.kps) file with have the correct path.
+
+Once you have compiled the keyboard and built the keyboard package successfully, you're ready to move on to submitting your keyboard project folder. (In this example, the "ausephon" folder would be submitted, but the "charis" folder would not be submitted.)

--- a/developer/keyboards/github/step-2.md
+++ b/developer/keyboards/github/step-2.md
@@ -86,6 +86,6 @@ release/shared/fonts/sil/charis - where the "charis" folder contains the files f
 
 The purpose of all this is to get the proper path when referencing these "shared" font files from the keyboard package. You won't be including any of the shared font files in your keyboard submission, but the paths to the fonts will be correct because you created the same folder structure used in Keyman's keyboards repository.
 
-When specifying the font files for the keyboard package (on the Packaging tab in Keyman Developer), navigate to the correct subfolder under the "shared" folder ("charis" in this example), so that the package source (.kps) file with have the correct path.
+When specifying the font files for the keyboard package (on the Packaging tab in Keyman Developer), navigate to the correct subfolder under the "shared" folder ("charis" in this example), so that the package source (.kps) file will have the correct path.
 
 Once you have compiled the keyboard and built the keyboard package successfully, you're ready to move on to submitting your keyboard project folder. (In this example, the "ausephon" folder would be submitted, but the "charis" folder would not be submitted.)


### PR DESCRIPTION
This pull request adds information about how to access shared fonts when using the GitHub UI to submit a keyboard.

In addition, some references to obsolete files have been removed.