### PR TITLE
Add KB article on migrating from KMFL to Keyman for Linux

### DIFF
--- a/knowledge-base/kb0114.md
+++ b/knowledge-base/kb0114.md
@@ -1,3 +1,7 @@
+# HOWTO: Migrate from KMFL to Keyman for Linux
+
+KMFL hasn't been maintained for many years so we recommend users perform the following steps to migrate .kmn files to .kmp files and use Keyman for Linux.
+
 With a little more work this can be entirely done on Linux with Keyman 17+:
 
 ## Prerequisites
@@ -8,13 +12,16 @@ With a little more work this can be entirely done on Linux with Keyman 17+:
   sudo apt install npm
   ```
 
-  For older Ubuntu versions consult the nodejs.org website.
+  For older Ubuntu versions consult the [nodejs.org website](https://nodejs.org).
 
 - Then install the Keyman keyboard compiler:
 
   ```bash
   sudo npm install -g @keymanapp/kmc
   ```
+
+- You'll also need [install Keyman for Linux](https://help.keyman.com/products/linux/current-version/common/) for installing the .kmp keyboard package later:
+
 
 ## Convert the .kmn source file into a .kmp keyboard package
 
@@ -58,8 +65,12 @@ With a little more work this can be entirely done on Linux with Keyman 17+:
   kmc build mykeyboard.kpj
   ```
 
-In the current version (17.0.326) this will fail with `"TypeError: Cannot read properties of undefined (reading 'description')"` (issue [#11856](https://github.com/keymanapp/keyman/issues/11856)), but it will already have created the .kmp file in the `build`
-subdirectory. You can install the .kmp file with:
+Disregard the error: `"TypeError: Cannot read properties of undefined (reading 'description')"`, as the compiler will already have created the .kmp file in the `build`
+subdirectory. 
+
+## Use Keyman for Linux to install the .kmp keyboard package 
+
+You can install the .kmp file with:
 
 ```bash
 km-package-install -f build/mykeyboard.kmp
@@ -67,10 +78,10 @@ km-package-install -f build/mykeyboard.kmp
 
 or with the Keyman Configuration tool.
 
-(To properly do this without an error, you'll have to add some additional fields to the .kps file. It's easiest to let the `kmconvert` tool generate a template which will contain all necessary fields:
+To properly do this without an error, you'll have to add some additional fields to the .kps file. It's easiest to let the `kmconvert` tool generate a template which will contain all necessary the fields:
 
 ```bash
 kmconvert template -id mykeyboard
 ```
 
-Unfortunately this tools isn't available for Linux yet. You should be able to use it in wine though.)
+Unfortunately this tools isn't available for Linux yet. You should be able to use it in wine though.

--- a/knowledge-base/kb0114.md
+++ b/knowledge-base/kb0114.md
@@ -1,0 +1,76 @@
+With a little more work this can be entirely done on Linux with Keyman 17+:
+
+## Prerequisites
+
+- You'll need node.js, version 18.0 or later. On Ubuntu 24.04 this can be installed with:
+
+  ```bash
+  sudo apt install npm
+  ```
+
+  For older Ubuntu versions consult the nodejs.org website.
+
+- Then install the Keyman keyboard compiler:
+
+  ```bash
+  sudo npm install -g @keymanapp/kmc
+  ```
+
+## Convert the .kmn source file into a .kmp keyboard package
+
+(replace `mykeyboard` with the name of your .kmn file)
+- Create a file `mykeyboard.kpj`:
+
+  ```xml
+  <KeymanDeveloperProject>
+    <Options>
+      <Version>2.0</Version>
+    </Options>
+  </KeymanDeveloperProject>
+  ```
+
+- Create a file `source/mykeyboard.kps`:
+
+  ```xml
+  <Package>
+    <Info>
+      <Name>MyKeyboard</Name>
+    </Info>
+    <Files>
+      <File>
+        <Name>../build/mykeyboard.kmx</Name>
+      </File>
+    </Files>
+    <Keyboards>
+      <Keyboard>
+        <Name>MyKeyboard</Name>
+        <ID>mykeyboard</ID>
+      </Keyboard>
+    </Keyboards>
+  </Package>
+  ```
+
+- Move your .kmn file to `source/mykeyboard.kmn`.
+
+- Build with:
+
+  ```bash
+  kmc build mykeyboard.kpj
+  ```
+
+In the current version (17.0.326) this will fail with `"TypeError: Cannot read properties of undefined (reading 'description')"` (issue [#11856](https://github.com/keymanapp/keyman/issues/11856)), but it will already have created the .kmp file in the `build`
+subdirectory. You can install the .kmp file with:
+
+```bash
+km-package-install -f build/mykeyboard.kmp
+```
+
+or with the Keyman Configuration tool.
+
+(To properly do this without an error, you'll have to add some additional fields to the .kps file. It's easiest to let the `kmconvert` tool generate a template which will contain all necessary fields:
+
+```bash
+kmconvert template -id mykeyboard
+```
+
+Unfortunately this tools isn't available for Linux yet. You should be able to use it in wine though.)


### PR DESCRIPTION
Addresses #94 on helping Linux users migrate from KMFL to Keyman for Linux

First commit was @ermshiperete 's answer on the [community site forum](https://community.software.sil.org/t/how-to-install-an-kmn-source-kmfl-file-onto-ubuntu-24-04/8864/5) (same response on Linux-user group.

Additional commits for formatting, and tweaking the section about a kmc compilation error.