### PR TITLE
Update kb0106.md

### DIFF
--- a/knowledge-base/kb0106.md
+++ b/knowledge-base/kb0106.md
@@ -7,26 +7,22 @@ to achieve.
 See [Keyman Cloud Keyboard Repository](/developer/keyboards/) for details on how
 to work with the Keyboards repository.
 
-This KB article lists two possible ways to download just a single keyboard folder. First, locate the keyboard folder you wish to download from [Keyman's Keyboard Repository](https://github.com/keymanapp/keyboards/tree/master). 
+This KB article lists one possible way to download just a single keyboard folder. First, locate the keyboard folder you wish to download from [Keyman's Keyboard Repository](https://github.com/keymanapp/keyboards/tree/master). 
 
 In this article, we'll be downloading the SIL IPA keyboard at [Keyman's SIL IPA Keyboard folder](https://github.com/keymanapp/keyboards/tree/master/release/sil/sil_ipa).
-
-## Use an SVN client
-You can use a command line SVN client to download a single folder:
-```cmd
-svn export https://github.com/keymanapp/keyboards/branches/master/release/sil/sil_ipa
-```
-
-This will export the sil_ipa keyboard into the `sil_ipa` folder. A Windows
-SVN command line client is available with [sliksvn](https://sliksvn.com/download/).
 
 ## Use a web site to download a zip file
 The website https://download-directory.github.io/ allows you to download a
 single folder from GitHub.
 - Simply paste the keyboard folder into the form.  
 e.g. keyboard folder: 
-https://github.com/keymanapp/keyboards/branches/master/release/sil/sil_ipa
+https://github.com/keymanapp/keyboards/tree/master/release/sil/sil_ipa
 - Press Enter.
 
 This will download a ZIP file containing the folder which you can extract onto
 your computer.
+
+Note that you may want to change the default name of the ZIP file ("keymanapp keyboards master release-sil_sil_ipa.zip" in this example)
+to something else ("sil_ipa.zip" for example) when downloading the file.
+
+Note also that attempting to download a large keyboard (or group of keyboards) may fail due to the large size.


### PR DESCRIPTION
As of 2024, GitHub no longer supports SVN access, so that method of getting a keyboard folder no longer works.

Also updated example to use a functioning path.