### PR TITLE
docs: Update API's for adjusting Android longpress delay

### DIFF
--- a/developer/engine/android/18.0/KMManager/getLongpressDelay.md
+++ b/developer/engine/android/18.0/KMManager/getLongpressDelay.md
@@ -1,0 +1,38 @@
+---
+title: KMManager.getLongpressDelay()
+---
+
+## Summary
+
+The `getLongpressDelay()` method returns from stored preference the number of milliseconds to trigger a longpress gesture.
+Defaults to 500 milliseconds.
+
+## Syntax
+
+```java
+int KMManager.getLongpressDelay()
+```
+
+### Returns
+Returns the number of milliseconds to trigger a longpress gesture. This preference is stored at the app level and is applied to all Keyman keyboards.
+
+## Description
+Use this method to get details about how long to press a key for longpress keys to appear.
+
+## Examples
+
+### Example: Using `getLongpressDelay()`
+
+The following code illustrates the use of `getLongpressDelay()`:
+```java  
+  int currentDelayTimeMS = KMManager.getLongpressDelay();
+
+  currentDelayTimeMS += 250; // ms
+```
+
+## History
+Keyman Engine for Android 18.0: New function.
+
+## See also
+* [sendOptionsToKeyboard](sendOptionsToKeyboard)
+* [setLongpressDelay](setLongpressDelay)

--- a/developer/engine/android/18.0/KMManager/index.md
+++ b/developer/engine/android/18.0/KMManager/index.md
@@ -137,6 +137,9 @@ The KMManager is the core class which provides most of the methods and constants
 [`getLanguagePredictionPreferenceKey()`](getLanguagePredictionPreferenceKey)
 : returns a String to use as a shared preference key to store whether the LMLayer should enable suggestions for a given language.
 
+[`getLongpressDelay()`](getLongpressDelay)
+: returns from stored preference the number of milliseconds to trigger a longpress gesture
+
 [`getMaySendCrashReport()`](getMaySendCrashReport)
 : returns whether Keyman Engine is allowed to send crash reports over the network to sentry.keyman.com
 
@@ -209,6 +212,9 @@ The KMManager is the core class which provides most of the methods and constants
 [`removeKeyboardEventListener()`](removeKeyboardEventListener)
 : removes the specified listener from the list of keyboard event listeners
 
+[`sendOptionsToKeyboard()`](sendOptionsToKeyboard)
+: sends options like longpress delay to the KeymanWeb keyboard
+
 [`setCanAddNewKeyboard()`](setCanAddNewKeyboard)
 : sets whether adding a new keyboard is allowed
 
@@ -241,6 +247,9 @@ The KMManager is the core class which provides most of the methods and constants
 
 ~~`setKeymanLicense()`~~ `(Deprecated)`
 : sets the developer license/key pair to unlock Keyman Engine
+
+[`setLongpressDelay()`](setLongpressDelay)
+: stores the longpress delay in milliseconds as a preference.
 
 [`setMaySendCrashReport()`](setMaySendCrashReport)
 : sets whether Keyman Engine can send crash reports over the network to sentry.keyman.com

--- a/developer/engine/android/18.0/KMManager/sendOptionsToKeyboard.md
+++ b/developer/engine/android/18.0/KMManager/sendOptionsToKeyboard.md
@@ -1,0 +1,41 @@
+---
+title: KMManager.sendOptionsToKeyboard()
+---
+
+## Summary
+
+The `sendOptionsToKeyboard()` method sends options like longpress delay to the KeymanWeb keyboard.
+
+## Syntax
+
+```java
+KMManager.sendOptionsToKeyboard()
+```
+
+## Description
+Use this method to update options in the KeymanWeb keyboard.
+* Number of milliseconds to trigger a longpress gesture
+
+This method requires a keyboard to be loaded for the values to take effect.
+
+## Examples
+
+### Example: Using `sendOptionsToKeyboard()`
+
+The following code illustrates the use of `sendOptionsToKeyboard()`:
+```java
+    int currentDelayTimeMS = 250;
+
+    // Store currentDelayTimeMS
+    KMManager.setLongpressDelay(currentDelayTimeMS);
+
+    // Apply the keyboard options
+    KMManager.sendOptionsToKeyboard();
+```
+
+## History
+Keyman Engine for Android 18.0: New function.
+
+## See also
+* [getLongpressDelay](getLongpressDelay)
+* [setLongpressDelay](setLongpressDelay)

--- a/developer/engine/android/18.0/KMManager/setLongpressDelay.md
+++ b/developer/engine/android/18.0/KMManager/setLongpressDelay.md
@@ -13,7 +13,7 @@ KMManager.setLongpressDelay(int longpressDelay)
 ```
 ### Parameter
 `longpressDelay`
-: The number of milliseconds
+: The number of milliseconds, ranging from 300 ms to 1500 ms.
 
 ## Description
 Use this method to store how many milliseconds to trigger a longpress as a preference.

--- a/developer/engine/android/18.0/KMManager/setLongpressDelay.md
+++ b/developer/engine/android/18.0/KMManager/setLongpressDelay.md
@@ -1,0 +1,42 @@
+---
+title: KMManager.setLongpressDelay()
+---
+
+## Summary
+
+The `setLongpressDelay()` method sets the number of milliseconds to trigger a longpress gesture as a stored preference.
+
+## Syntax
+
+```java
+KMManager.setLongpressDelay(int longpressDelay)
+```
+### Parameter
+`longpressDelay`
+: The number of milliseconds
+
+## Description
+Use this method to store how many milliseconds to trigger a longpress as a preference.
+This preference is stored at the Keyman app level, and is applied to all Keyman keyboards.
+
+## Examples
+
+### Example: Using `setLongpressDelay()`
+
+The following code illustrates the use of `setLongpressDelay()`:
+```java
+    int currentDelayTimeMS = 250;
+
+    // Store currentDelayTimeMS
+    KMManager.setLongpressDelay(currentDelayTimeMS);
+
+    // Apply the keyboard options
+    KMManager.sendOptionsToKeyboard();
+```
+
+## History
+Keyman Engine for Android 18.0: New function.
+
+## See also
+* [getLongpressDelay](getLongpressDelay)
+* [sendOptionsToKeyboard](sendOptionsToKeyboard)

--- a/developer/engine/android/18.0/KMManager/setLongpressDelay.md
+++ b/developer/engine/android/18.0/KMManager/setLongpressDelay.md
@@ -25,7 +25,7 @@ This preference is stored at the Keyman app level, and is applied to all Keyman 
 
 The following code illustrates the use of `setLongpressDelay()`:
 ```java
-    int currentDelayTimeMS = 250;
+    int currentDelayTimeMS = 300;
 
     // Store currentDelayTimeMS
     KMManager.setLongpressDelay(currentDelayTimeMS);


### PR DESCRIPTION
Documents Keyman Engine for Android 18.0 API changes for keymanapp/keyman#12170 and keymanapp/keyman#12185

* getLongpressDelay
* sendKeyboardOptions
* setLongpressDelay
