### PR TITLE
chore: Revert "chore: Revert "change: use published Keyman Engine API to fetch keyboards in keyboard help pages""

### DIFF
--- a/_includes/includes/head.php
+++ b/_includes/includes/head.php
@@ -8,7 +8,9 @@
 
   // Variables used to manage and trigger debugging tests.
   // Simply defining the variable below is enough to trigger debug mode.
-  // $kmw_dev_path = 'http://localhost/release/unminified/web';
+  // Advice:  copy a locally-compiled /web/build/publish/debug folder as
+  // /cdn/dev/local-web, then uncomment the following line.
+  // $kmw_dev_path = cdn("local-web/keymanweb.js");
 
   if(!isset($title)){
     $title = 'Keyman | Type to the world in your language';
@@ -98,13 +100,12 @@
       }
     }
     if(!isset($kmw_dev_path)) {
-      $kmw_version_number = '16.0.147'; // TEMP: work around keymanapp/keyman#11467, roll back to 16.0-stable until fixed
   ?>
       <script src='https://s.keyman.com/kmw/engine/<?=$kmw_version_number?>/keymanweb.js'></script>
   <?php
     } else {
   ?>
-      <script src='<?=$kmw_dev_path?>/keymanweb.js'></script>
+      <script src='<?=$kmw_dev_path?>'></script>
   <?php
     }
   ?>

--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -1177,12 +1177,10 @@ table.platform {
 #osk-phone,
 #osk-tablet{
 	position: relative;
-	z-index: -2;
 }
 
 #osk .kmw-osk-inner-frame{
 	height: 320px !important;
-	font-size: 2em !important;
   padding: 4px 0 4px 4px;
 }
 
@@ -1190,14 +1188,12 @@ table.platform {
   padding-top: 6px !important;
 	height: 256px !important;
   width: 528px !important;
-	font-size: 1.5em !important;
 }
 
 #osk-tablet .kmw-osk-inner-frame{
   padding-top: 6px !important;
 	width: 726px !important;
   height: 372px !important;
-	font-size: 1.5em !important;
 }
 
 #osk-container,
@@ -1415,7 +1411,6 @@ body[data-device='Unknown'] #osk-tablet-container {
 	}
 	#osk .kmw-osk-inner-frame{
 		height: 280px;
-		font-size: 1.8em !important;
 	}
 	.footer-tab-holder{
 		display: none;
@@ -1568,7 +1563,6 @@ body[data-device='Unknown'] #osk-tablet-container {
 	}
 	#osk .kmw-osk-inner-frame{
 		height: 140px;
-		font-size: 1em !important;
 	}
 	#keymanExample{
 		overflow-x: scroll;


### PR DESCRIPTION
Reverts: keymanapp/help.keyman.com#1518
Fixes: keymanapp/keyman#12345
Co-authored-by: @ermshiperete 

Alongside additional CSS fixes:

1. Remove unnecessary font-size hammers for the OSK as KMW does a good job of managing font size itself now
2. Remove unnecessary `z-index: -2` for OSK that blocked interaction with earlier versions of KMW, as KMW documentation keyboards are no longer interactive