### PR TITLE
fix: Skip CDN for --debug builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,6 +46,6 @@ builder_run_action configure  bootstrap_configure
 builder_run_action clean      clean_docker_container $HELP_IMAGE_NAME $HELP_CONTAINER_NAME
 builder_run_action stop       stop_docker_container  $HELP_IMAGE_NAME $HELP_CONTAINER_NAME
 builder_run_action build      build_docker_container $HELP_IMAGE_NAME $HELP_CONTAINER_NAME
-builder_run_action start      start_docker_container $HELP_IMAGE_NAME $HELP_CONTAINER_NAME $HELP_CONTAINER_DESC $HOST_HELP_KEYMAN_COM $PORT_HELP_KEYMAN_COM
+builder_run_action start      start_docker_container $HELP_IMAGE_NAME $HELP_CONTAINER_NAME $HELP_CONTAINER_DESC $HOST_HELP_KEYMAN_COM $PORT_HELP_KEYMAN_COM $BUILDER_CONFIGURATION
 
 builder_run_action test       test_docker_container

--- a/resources/init-container.sh
+++ b/resources/init-container.sh
@@ -5,7 +5,11 @@ rm -f keyboard/index.cache
 cd keyboard
 php -d include_path=/var/www/html/_includes:. _build_cache.php
 
-echo "---- Generating CDN ---"
-cd ../cdn
-php -d include_path=/var/www/html/_includes:. cdnrefresh.php
-cd ..
+if [[ ! $1 =~ "debug" ]]; then
+  echo "---- Generating CDN ---"
+  cd ../cdn
+  php -d include_path=/var/www/html/_includes:. cdnrefresh.php
+  cd ..
+else
+  echo "Skip Generating CDN"
+fi

--- a/resources/init-container.sh
+++ b/resources/init-container.sh
@@ -11,5 +11,6 @@ if [[ ! $1 =~ "debug" ]]; then
   php -d include_path=/var/www/html/_includes:. cdnrefresh.php
   cd ..
 else
-  echo "Skip Generating CDN"
+  echo "Skip Generating CDN and clean CDN cache"
+  rm -rf ../cdn/deploy
 fi


### PR DESCRIPTION
Mirrors keymanapp/keyman.com#471 to skip generating CDN if `./build.sh --debug`

This uses `BOOTSTRAP_VERSION v0.10` so the optional debug parameter is passed to init-container.sh
