### PR TITLE
Update PrimerPrep URLs

### DIFF
--- a/developer/17.0/guides/lexical-models/tutorial/step-3.md
+++ b/developer/17.0/guides/lexical-models/tutorial/step-3.md
@@ -15,7 +15,7 @@ One simple way to create your TSV file is to use the **PrimerPrep**
 tool:
 
 1.  Install PrimerPrep (info at
-    <http://lingtransoft.info/apps/primerprep>)
+    https://software.sil.org/primerprep, download from https://software.sil.org/primerprep/downloads)
 2.  Run PrimerPrep (note that on the first run it often takes a couple
     of minutes; subsequent starts are faster)
 3.  Click on the Add Text(s) button; select one or more plain text

--- a/developer/17.0/guides/lexical-models/tutorial/step-3.md
+++ b/developer/17.0/guides/lexical-models/tutorial/step-3.md
@@ -16,8 +16,7 @@ tool:
 
 1.  Install PrimerPrep (info at
     https://software.sil.org/primerprep, download from https://software.sil.org/primerprep/downloads)
-2.  Run PrimerPrep (note that on the first run it often takes a couple
-    of minutes; subsequent starts are faster)
+2.  Run PrimerPrep (note that the first run might be slow; subsequent starts are faster)
 3.  Click on the Add Text(s) button; select one or more plain text
     (UTF-8) files in the language to analyze
 4.  The word list with frequency counts appears in the pane to the right


### PR DESCRIPTION
Request from Jeff Heath (author of PrimerPrep):
```
I noticed on https://help.keyman.com/developer/current-version/guides/lexical-models/tutorial/step-3 
that it points to lingtransoft.info for the PrimerPrep installation. 
That link should just point to https://software.sil.org/primerprep/ and/or 
https://software.sil.org/primerprep/downloads/.

Also the next line can be toned down a bit, maybe:
Run PrimerPrep (note that the first run might be slow; subsequent starts are faster)

```
