### PR TITLE
fix: override KeymanWeb CSS for z-index for documentation OSK

### DIFF
--- a/cdn/dev/css/keyboard.css
+++ b/cdn/dev/css/keyboard.css
@@ -53,7 +53,7 @@
 }
 
 #osk .desktop.kmw-osk-inner-frame .kmw-key-square {
-  
+
   border-bottom: solid 2px rgb(204,204,204);
 }
 
@@ -93,3 +93,7 @@ samp {
   margin-top: 20px;
 }
 
+#osk .kmw-key-square {
+  /* #1548: z-index interference */
+  z-index: inherit;
+}


### PR DESCRIPTION
A more comprehensive fix would need to be made to KeymanWeb, but that should be part of a more systematic review of KeymanWeb's CSS in the future.

Fixes: #1548