### PR TITLE
feat: Add optional `language` header to set HTML lang attribute 📓

### DIFF
--- a/_includes/header.php
+++ b/_includes/header.php
@@ -12,6 +12,7 @@
     $canonicalLink = "/keyboard/" . $folders[2] . "/current-version";
     head([
       'title' =>$pagetitle,
+      'language' => isset($language) ? $language : '',
       'pagename' => isset($pagename) ? $pagename : $pagetitle,
       'css' => ['template.css','keyboard.css','keys.css'],
       'js' => ['kbd-docs.js'],
@@ -22,6 +23,7 @@
   }else{
     head([
       'title' =>$pagetitle,
+      'language' => isset($language) ? $language : '',
       'pagename' => isset($pagename) ? $pagename : $pagetitle,
       'css' => ['template.css','keyboard.css','keys.css'],
       'showMenu' => true,

--- a/_includes/includes/head.php
+++ b/_includes/includes/head.php
@@ -30,8 +30,13 @@
   }
 ?>
 <!DOCTYPE html>
-
-<html>
+<?php
+  if(!isset($language) || empty($language)) {
+    echo "<html>\n";
+  } else {
+    echo "<html lang='" . $language . "'>\n";
+  }
+?>
 <head>
   <meta charset="utf-8">
   <?php

--- a/_includes/includes/head.php
+++ b/_includes/includes/head.php
@@ -31,7 +31,7 @@
 ?>
 <!DOCTYPE html>
 <?php
-  if(!isset($language) || empty($language)) {
+  if(empty($language)) {
     echo "<html>\n";
   } else {
     echo "<html lang='" . $language . "'>\n";

--- a/_includes/includes/kb_doc_template.php
+++ b/_includes/includes/kb_doc_template.php
@@ -41,7 +41,7 @@
     }else{
       $title = 'Keyman | Type to the world in your language';
     }
-    if(isset($args['language']) && !empty($args['language'])){
+    if(!empty($args['language'])){
       $language = $args['language'];
     }
     if(isset($args['css'])){

--- a/_includes/includes/kb_doc_template.php
+++ b/_includes/includes/kb_doc_template.php
@@ -37,9 +37,12 @@
     }
 
     if(isset($args['title'])){
-        $title = $args['title'];
+      $title = $args['title'];
     }else{
-        $title = 'Keyman | Type to the world in your language';
+      $title = 'Keyman | Type to the world in your language';
+    }
+    if(isset($args['language']) && !empty($args['language'])){
+      $language = $args['language'];
     }
     if(isset($args['css'])){
       $css = array();

--- a/_includes/includes/template.php
+++ b/_includes/includes/template.php
@@ -51,7 +51,7 @@
     }else{
       $title = 'Keyman Help | Type to the world in your language';
     }
-    if(isset($args['language'])){
+    if(!empty($args['language'])){
       $language = $args['language'];
     }
     if(isset($args['css'])){

--- a/_includes/includes/template.php
+++ b/_includes/includes/template.php
@@ -47,9 +47,12 @@
     }
 
     if(isset($args['title'])){
-        $title = $args['title'];
+      $title = $args['title'];
     }else{
-        $title = 'Keyman Help | Type to the world in your language';
+      $title = 'Keyman Help | Type to the world in your language';
+    }
+    if(isset($args['language'])){
+      $language = $args['language'];
     }
     if(isset($args['css'])){
       $css = array();


### PR DESCRIPTION
Relates to keymanapp/keyman.com#383

This allows PHP pages to include `$language` in the headers to set the HTML lang attribute.
Markdown files would be handled by keymanapp/shared-sites#37 (lang or language?)

I tested locally by manually adding 
```php
  'language' => 'th',
``` 
in https://github.com/keymanapp/help.keyman.com/blob/fb354f0a0db9989cbe2caed4492f897ff4f3fdcb/index.php#L7-L12

----

A keyboard help page would add
```php
  $language = 'my';
```
to https://github.com/keymanapp/help.keyman.com/blob/fb354f0a0db9989cbe2caed4492f897ff4f3fdcb/keyboard/sil_myanmar_my3/1.7.3/sil_myanmar_my3.php#L1-L5

