### PR TITLE
feat(seo): change keyboard help page title from h2 to h1

### DIFF
--- a/_includes/includes/kb_doc_template.php
+++ b/_includes/includes/kb_doc_template.php
@@ -205,7 +205,7 @@
             <article>
       END;
     if(!empty($pagename)){
-      $html.='<h2 class="red underline">'.$pagename.'</h2>';
+      $html.='<h1 class="red underline">'.$pagename.'</h1>';
     }
 
     echo $html;


### PR DESCRIPTION
This is out of the F3: Hackathon module during the Keyman team meetings in CNX Nov 2024.

Doug Higby suggested for improving keyboard SEO that pages:

> Need keywords in both title and H1 

This changes the keyboard title from h2 to h1

## Screenshot with the change
![image](https://github.com/user-attachments/assets/0ff30f96-5ec2-4f8f-9dcd-f851bc7b87e3)