### PR TITLE
fix: remove .php extension when redirecting URLs in /keyboard

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -180,7 +180,7 @@ Redirect "/bookmarklet" "/products/bookmarklet"
 
 Redirect "/kb" "/knowledge-base"
 
-# Redirect to kb handler
+# Rewrite to kb handler
 RewriteRule "^knowledge-base/(\d+)$" "/knowledge-base/index.php?id=$1" [L]
 
 # Redirect error code shortlinks
@@ -213,12 +213,13 @@ RewriteRule "^((.+)/)?index(\.php)?$" "$1" [R,L]
 
 # Remove .php extension and redirect
 RewriteCond "$1.php" -f
-RewriteCond "$1" !-d
 RewriteRule "^(.+)\.php$" "$1" [R,L]
 
-# Remove .php extension and redirect - but only for Keyman Developer API docs for now
+# Remove .php extension and redirect - but only for Keyman Developer API docs
+# for now because this is the only current place where .md files are referenced
+# directly (so we don't want to promote use of .md in URLs)
 RewriteCond "$1.md" -f
-RewriteRule "^(developer/(current-version|\d+\.\d+)/reference/api/.+)\.md$" "$1" [R,END]
+RewriteRule "^(developer/(current-version|latest-version|\d+\.\d+)/reference/api/.+)\.md$" "$1" [R,END]
 
 # Redirect folder without / to include /
 RewriteCond "{DOCUMENT_ROOT}/$1" -d
@@ -227,7 +228,9 @@ RewriteCond "{DOCUMENT_ROOT}/$1.md" !-f
 RewriteRule "^(.+[^/])$" "$1/" [R,END]
 
 #
-# PHP rewriting
+# Rewrite bare URLs to load appropriate .php:
+# * mdhost.php for .md Markdown files, or
+# * the referenced .php itself
 #
 
 # Rewrite file to file.md

--- a/keyboard/redir.php
+++ b/keyboard/redir.php
@@ -28,8 +28,8 @@
     $v = array_pop($versions);
   }
 
-  $filename = "$v/$q.php";
-  if(!file_exists($filename)) {
+  $filename = "$v/$q";
+  if(!file_exists("$filename.php")) {
     //Debug purposes: echo "Failed to find target filename\n";
     header('Location: /keyboard');
     exit;


### PR DESCRIPTION
Also removes the filter for file.php vs file/ conflict as I verified that there are no impacted folders. There are a few places where there is a xxx.php and a xxx/ folder, but none of them are problematic:

```
./developer/14.0/guides/develop/imx/web.php ==> ./developer/14.0/guides/develop/imx/web
./developer/15.0/guides/develop/imx/web.php ==> ./developer/15.0/guides/develop/imx/web
./developer/16.0/guides/develop/imx/web.php ==> ./developer/16.0/guides/develop/imx/web
./keyboard/khmer_angkor/1.0.5/khmer_angkor.php ==> ./keyboard/khmer_angkor/1.0.5/khmer_angkor
./keyboard/khmer_angkor/1.0.6/khmer_angkor.php ==> ./keyboard/khmer_angkor/1.0.6/khmer_angkor
./keyboard/khmer_angkor/1.0.7/khmer_angkor.php ==> ./keyboard/khmer_angkor/1.0.7/khmer_angkor
./keyboard/khmer_angkor/1.0.8/khmer_angkor.php ==> ./keyboard/khmer_angkor/1.0.8/khmer_angkor
./keyboard/khmer_angkor/1.0.9/khmer_angkor.php ==> ./keyboard/khmer_angkor/1.0.9/khmer_angkor
./keyboard/khmer_angkor/1.1/khmer_angkor.php ==> ./keyboard/khmer_angkor/1.1/khmer_angkor
./keyboard/khmer_angkor/1.2/khmer_angkor.php ==> ./keyboard/khmer_angkor/1.2/khmer_angkor
./keyboard/khmer_angkor/1.3/khmer_angkor.php ==> ./keyboard/khmer_angkor/1.3/khmer_angkor
./keyboard/khmer_angkor/1.3.1/khmer_angkor.php ==> ./keyboard/khmer_angkor/1.3.1/khmer_angkor
./keyboard/khmer_angkor/1.4/khmer_angkor.php ==> ./keyboard/khmer_angkor/1.4/khmer_angkor
./keyboard/khmer_angkor/1.5/khmer_angkor.php ==> ./keyboard/khmer_angkor/1.5/khmer_angkor
```

For reference, used the following script:

```
find . -name '*.php' > php-files
node phpfi.js
```

phpfi.js:

```
const fs = require('fs');
const path = require('path');
const files = fs.readFileSync('php-files','utf-8').split('\n');
for(const file of files) {
  const dir = path.dirname(file) + '/' + path.basename(file, '.php');
  if(fs.existsSync(dir) && fs.statSync(dir).isDirectory()) {
    console.log(`${file} ==> ${dir}`);
  }
}
```

Fixes: #1716