### PR TITLE
fix: 404 Not Found link in docs

### DIFF
--- a/keyboard/burushaski_girminas/2.0.24/burushaski_girminas.php
+++ b/keyboard/burushaski_girminas/2.0.24/burushaski_girminas.php
@@ -21,7 +21,7 @@
   <tr>
     <td width="96%" height="1802"align="left" valign="top"><p class="style11">
       <h3 class="style11"><a name="desktop"></a>Typing  characters with Buruśaaski Girminas Keyboard (Desktop, Laptop) </h3>
-      <p><span class="style11">First of all, please click download link to <a href="https://keyman.com/keyboards/Buruśaaski_girminas?bcp47=bsk-latn" target="new">download</a> the Buruśaaski Girminas for your desktop or laptop.
+      <p><span class="style11">First of all, please click download link to <a href="https://keyman.com/keyboards/burushaski_girminas" target="new">download</a> the Buruśaaski Girminas for your desktop or laptop.
         </hp>
       </span></p>
       <p>For  diacritic vowels with&nbsp;<strong>tilde</strong>, there is only one rule -- on your keyboard press tilde (~)&nbsp; followed by your desired vowel.&nbsp; The <strong>tilde</strong> is used for nasalized vowels in Buruśaski in very limited situations. &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;</p>

--- a/products/android/10.0/index.php
+++ b/products/android/10.0/index.php
@@ -261,7 +261,7 @@ head([
     Once the keyboard has been downloaded, you should be able to use it as normal.
     <br/>
     To learn how to create a custom installable keyboard,
-    <a href="../../../developer/10.0/guides/distribute/">click here</a>.
+    <a href="/developer/10.0/guides/distribute/">click here</a>.
   </p>
 
   <h2>Granting storage permission</h2>

--- a/products/android/10.0/index.php
+++ b/products/android/10.0/index.php
@@ -261,7 +261,7 @@ head([
     Once the keyboard has been downloaded, you should be able to use it as normal.
     <br/>
     To learn how to create a custom installable keyboard,
-    <a href="https://help.keyman.com/developer/10.0/distribute/">click here</a>.
+    <a href="../../../developer/10.0/guides/distribute/">click here</a>.
   </p>
 
   <h2>Granting storage permission</h2>


### PR DESCRIPTION
Part of: https://github.com/keymanapp/keyman.com/issues/415.

Info:
These links were returning 404 Not Found even though the content exists.

This PR is ready for review.