### PR TITLE
chore: redirect of some capital letters in url

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -23,6 +23,14 @@ ErrorDocument 404 /_includes/errors/404
 # Handle IIS bug which created links to /DEVELOPER instead of /developer
 RedirectMatch "/DEVELOPER(.*)" "/developer$1"
 
+RedirectMatch "/PRODUCTS(.*)" "/products$1"
+
+RedirectMatch "(.*)/ENGINE(.*)" "$1/engine$2"
+
+RedirectMatch "(.*)/WEB(.*)" "$1/web$2"
+
+RedirectMatch "(.*)/DESKTOP(.*)" "$1/windows$2"
+
 #
 # Keyboard redirects -- must go before current-version
 #


### PR DESCRIPTION
More on: https://github.com/keymanapp/keyman.com/issues/415.

The .htaccess validation may be overlapping a bit with the existing rules in the file but this should remove the registration of 404 Not found of the capital URLs:

```
https://help.keyman.com/DEVELOPER/ENGINE/web/1.0/
...
https://help.keyman.com/DEVELOPER/ENGINE/web/1.0/index.php
...
https://help.keyman.com/DEVELOPER/ENGINE/WEB/10.0/guide/examples/automatic-control
https://help.keyman.com/DEVELOPER/ENGINE/web/10.0/guide/examples/automatic-control
...
https://help.keyman.com/DEVELOPER/ENGINE/web/11.0/reference/core/addHotKey.php
...
https://help.keyman.com/DEVELOPER/ENGINE/web/12.0/guide/examples
...
https://help.keyman.com/DEVELOPER/ENGINE/WEB/13.0
https://help.keyman.com/DEVELOPER/ENGINE/web/13.0/guide/
...
https://help.keyman.com/DEVELOPER/ENGINE/web/14.0/reference/core/
https://help.keyman.com/DEVELOPER/ENGINE/WEB/14.0/reference/core/addKeyboards
...=
https://help.keyman.com/DEVELOPER/ENGINE/WEB/15.0/guide/examples
...
https://help.keyman.com/DEVELOPER/ENGINE/web/16.0/
...
more
```

Descriptive reports: https://docs.google.com/spreadsheets/d/1On3WrJMyDo3QboQvl7S1sbtD1z3HO3JH/edit?usp=sharing&ouid=115939244027961768677&rtpof=true&sd=true

This PR is ready for review.