### PR TITLE
chore: broken internal URLs

### DIFF
--- a/developer/16.0/context/kmcomp.md
+++ b/developer/16.0/context/kmcomp.md
@@ -61,7 +61,7 @@ Usage: kmcomp [-s[s]] [-nologo] [-c] [-d] [-w] [-v[s|d]] [-source-path path] [-s
 :   Build only the `target` file from the project (only for .kpj)
 
 `-addhelplink path`
-:   path to help file on https://help.keyman.com/keyboards
+:   path to help file on https://help.keyman.com/keyboard
 
 `-color`
 :   If specified, forces color log mesages on.


### PR DESCRIPTION
Continue: https://github.com/keymanapp/keyman.com/issues/415

I'm using an audit result to determined the broken internal URLs. Please let me know if this is not a correct URL. Thanks!
![image](https://github.com/user-attachments/assets/1578a06a-deb1-40a2-8a76-70ea08284e26)
