### PR TITLE
chore: fixes Blocked due to other 4xx issue in Google Search Console

### DIFF
--- a/developer/cloud/search/1.0/index.php
+++ b/developer/cloud/search/1.0/index.php
@@ -10,7 +10,7 @@
 ?>
 <h2>Keyboard search API 1.0 Specification</h2>
 
-<p>Documents the <a href='https://api.keyman.com/search'>api.keyman.com/search</a> endpoint.</p>
+<p>Documents the <b>api.keyman.com/search</b> endpoint.</p>
 
 <p>This API is deprecated and has been replaced with <a href='../2.0'>version 2.0</a>.</p>
 

--- a/developer/cloud/search/2.0/index.md
+++ b/developer/cloud/search/2.0/index.md
@@ -2,7 +2,7 @@
 title: Keyboard search API 2.0 Specification
 ---
 
-Documents the [api.keyman.com/search/2.0](https://api.keyman.com/search/2.0) endpoint. Searches are run across keyboard names, identifiers and details, language names, script names and country names, and returns an array of keyboards that match.
+Documents the **api.keyman.com/search/2.0** endpoint. Searches are run across keyboard names, identifiers and details, language names, script names and country names, and returns an array of keyboards that match.
 
 Note: unlike the [Search 1.0 endpoint](../1.0), this endpoint always returns an array of keyboards. Version 1.0 would return arrays of matching languages and countries as well, but this has been consolidated into a flat array rather than a conceptual tree of results, which is easier for end users to understand and use.
 


### PR DESCRIPTION
A report on Google Search Console:
![Image](https://github.com/user-attachments/assets/f89fa61d-101b-4485-8698-6a8497e0966d)

The URL is being used on these pages: 
- https://help.keyman.com/developer/cloud/search/1.0/
- https://help.keyman.com/developer/cloud/search/2.0/

The Changes:
![image](https://github.com/user-attachments/assets/07ff05fd-1851-47f2-91b6-fc9a3d7b12ff)
![image](https://github.com/user-attachments/assets/f80c921b-47c4-4c40-ac9b-6b882dda50b5)
