### PR TITLE
refactor: clean up KeymanHosts usage and make consistent

### DIFF
--- a/_includes/includes/__kmwheader.php
+++ b/_includes/includes/__kmwheader.php
@@ -2,6 +2,7 @@
 <?php
 
 require_once("includes/servervars.php");
+use Keyman\Site\Common\KeymanHosts;
 
 // Variables used to manage and trigger debugging tests.
 // Simply defining the variable below is enough to trigger debug mode.
@@ -9,7 +10,7 @@ require_once("includes/servervars.php");
 
 function get_version($tier)
 {
-  $kmwbuild = @file_get_contents("https://api.keyman.com/version/web/$tier");
+  $kmwbuild = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com . "/version/web/$tier");
 
   if($kmwbuild) {
     $kmwbuild = json_decode($kmwbuild);

--- a/_includes/includes/head.php
+++ b/_includes/includes/head.php
@@ -98,7 +98,7 @@
     $kmw_version_number = '13.0.108';
     if(KeymanHosts::Instance()->Tier() != KeymanHosts::TIER_TEST) {
       // For performance reasons, we don't check KeymanWeb version on Test Tier
-      $kmw_version = @file_get_contents('https://api.keyman.com/version/web/stable');
+      $kmw_version = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com . '/version/web/stable');
       if($kmw_version !== FALSE) {
         $kmw_version = @json_decode($kmw_version);
         if($kmw_version !== NULL) $kmw_version_number = $kmw_version->version;
@@ -106,7 +106,7 @@
     }
     if(!isset($kmw_dev_path)) {
   ?>
-      <script src='https://s.keyman.com/kmw/engine/<?=$kmw_version_number?>/keymanweb.js'></script>
+      <script src='<?=KeymanHosts::Instance()->s_keyman_com?>/kmw/engine/<?=$kmw_version_number?>/keymanweb.js'></script>
   <?php
     } else {
   ?>
@@ -115,7 +115,7 @@
     }
   ?>
     <script>
-      keyman.init({keyboards:'https://s.keyman.com/keyboard/'});
+      keyman.init({keyboards:'<?=KeymanHosts::Instance()->s_keyman_com?>/keyboard/'});
     </script>
   <?php
     }

--- a/_includes/includes/history_utils.php
+++ b/_includes/includes/history_utils.php
@@ -6,14 +6,16 @@
  * Time: 11:51 AM
  */
 
+use Keyman\Site\Common\KeymanHosts;
+
 require_once("includes/servervars.php");
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 function get_history($platform, $version = '1.0') {
   // Reads straight from a file.  Likely to be useful for the history-exposing API.
-  $url = build_downloads_keyman_com_url("api/history/$platform/$version"); // Longform: "api/historydata.php?platform=$platform?version=$version".
+  $url = "/api/history/$platform/$version"; // Longform: "api/historydata.php?platform=$platform?version=$version".
 
-  $contents = @file_get_contents($url);
+  $contents = @file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . $url);
 
   if($contents === FALSE) {
     //header('HTTP/1.0 400 Invalid parameter');

--- a/_includes/includes/renderLanguageExample.php
+++ b/_includes/includes/renderLanguageExample.php
@@ -16,12 +16,13 @@
   History:          21 Dec 2009 - mcdurdin - Fixup rendering of special keys
 */
   require_once('servervars.php');
+  use Keyman\Site\Common\KeymanHosts;
 
   function renderLanguageExample($keyboard, $language, $morehelp = '', $toBrowser = true)
   {
 
     $keyboard = str_replace('Keyboard_','',$keyboard);
-    $string = "https://api.keyman.com/cloud/3.0/keyboards/".$keyboard;
+    $string = KeymanHosts::Instance()->SERVER_api_keyman_com . "/cloud/3.0/keyboards/".$keyboard;
     if(($json = @file_get_contents($string)) === FALSE) {
       return '';
     }

--- a/_includes/includes/servervars.php
+++ b/_includes/includes/servervars.php
@@ -43,17 +43,6 @@
     return "/cdn/dev/{$file}";
   }
 
-  function build_downloads_keyman_com_url($file) {
-    global $downloadsDomain, $TestServer;
-
-    $use_https = !$TestServer;
-    if($use_https == true) {
-      return "https://$downloadsDomain/$file";
-    } else {
-      return "http://$downloadsDomain/$file";
-    }
-  }
-
   /* The following function is needed for some pages but was only contained in an obsolete header file */
   $codeboxcount = 0;
   function codebox($s, $lang='')


### PR DESCRIPTION
* Splits the server-side and client-side references to keyman sites so that docker-based PHP can reference host.docker.internal on development machines for cross-references.

* TODO: update to `BOOTSTRAP_VERSION=v0.17` in build.sh before merge.

Relates-to: keymanapp/shared-sites#53
Relates-to: keymanapp/keyman.com#545
Relates-to: keymanapp/api.keyman.com#272
Relates-to: keymanapp/keymanweb.com#129