### PR TITLE
fix: properly handle paths in init-container.sh

### DIFF
--- a/resources/init-container.sh
+++ b/resources/init-container.sh
@@ -10,6 +10,7 @@ php -d include_path=/var/www/html/_includes:. _build_cache.php
 
 if [[ ! $1 =~ "debug" ]]; then
   echo "---- Generating CDN ---"
+  rm -rf "$THIS_SCRIPT_PATH/../cdn/deploy"
   cd "$THIS_SCRIPT_PATH/../cdn"
   php -d include_path=/var/www/html/_includes:. cdnrefresh.php
   cd ..

--- a/resources/init-container.sh
+++ b/resources/init-container.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+THIS_SCRIPT_PATH="$(dirname "$THIS_SCRIPT")"
+
 echo "--- Generating Keyboard Cache ---"
-rm -f keyboard/index.cache
-cd keyboard
+rm -f "$THIS_SCRIPT_PATH/../keyboard/index.cache"
+cd "$THIS_SCRIPT_PATH/../keyboard"
 php -d include_path=/var/www/html/_includes:. _build_cache.php
 
 if [[ ! $1 =~ "debug" ]]; then
   echo "---- Generating CDN ---"
-  cd ../cdn
+  cd "$THIS_SCRIPT_PATH/../cdn"
   php -d include_path=/var/www/html/_includes:. cdnrefresh.php
   cd ..
 else
   echo "Skip Generating CDN and clean CDN cache"
-  rm -rf ../cdn/deploy
+  rm -rf "$THIS_SCRIPT_PATH/../cdn/deploy"
 fi


### PR DESCRIPTION
Ports fix from keymanapp/keymanweb.com#136 to make the pathing in init-container.sh robust.