### PR TITLE
fix: Disallow all bots since staging site doesn't need to be indexed

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,7 +1,3 @@
-# This bot is too busy (300K+ visits/month across all keyman.com domains)
-User-agent: AhrefsBot
-Disallow: /
-
-# This bot is too busy (300K+ visits/month across all keyman.com domains)
-User-agent: TurnitinBot
+# Disallow all bots since we don't need anything idexed on the staging site
+User-agent: *
 Disallow: /


### PR DESCRIPTION
Staging site getting hammered by an Amazon bot causing an OOM bootloop

@mcdurdin recommends we disallow all bots since the staging site doesn't need to be indexed.