### PR TITLE
chore: Update fallback version of KeymanWeb to 18.0.235

### DIFF
--- a/_includes/includes/head.php
+++ b/_includes/includes/head.php
@@ -82,7 +82,7 @@
    else window.onload = downloadJSAtOnload;
   </script>
   <?php if(isset($IncludeKeymanWeb) && $IncludeKeymanWeb == true){
-    $kmw_version_number = '13.0.108';
+    $kmw_version_number = '18.0.235';
     if(KeymanHosts::Instance()->Tier() != KeymanHosts::TIER_TEST) {
       // For performance reasons, we don't check KeymanWeb version on Test Tier
       $kmw_version = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com . '/version/web/stable');


### PR DESCRIPTION
In the Development tier, if the other ancillary Keyman sites aren't running, then the site will fetch this fallback version of KeymanWeb from s.keyman.com

The previous version '13.0.108' doesn't render the keyboard layouts
