### PR TITLE
fix: Update links to edit product help files

### DIFF
--- a/_includes/includes/com.keyman.help.editpage.inc.php
+++ b/_includes/includes/com.keyman.help.editpage.inc.php
@@ -6,11 +6,11 @@
     $app =  "https://github.com/keymanapp/keyman/edit/master";
 
     $map = [
-      'android' => 'android/help/',
-      'iphone-and-ipad' => 'ios/help/',
-      'linux' => 'linux/help/',
-      'mac' => 'mac/help/',
-      'windows' => 'windows/src/desktop/help/'
+      'android' => 'android/docs/help/',
+      'iphone-and-ipad' => 'ios/docs/help/',
+      'linux' => 'linux/docs/help/',
+      'mac' => 'mac/docs/help/',
+      'windows' => 'windows/docs/help/'
     ];
     $maps = join('|', array_keys($map));
 


### PR DESCRIPTION
The footer link to edit product help pages is broken.
Comes out of the refactor from keymanapp/keyman#12424
which renamed the folders to the product help.

TODO (separate PR?):
- [ ] Handle old Keyman Desktop help content
https://github.com/keymanapp/help.keyman.com/blob/4e6fb0ac55572fea57e66d563e8702622a990b85/_includes/includes/com.keyman.help.editpage.inc.php#L30-L65
 
Fixes: #1999



