### PR TITLE
fix: remove documentation for never implemented feature of `if`

### DIFF
--- a/developer/language/reference/if.md
+++ b/developer/language/reference/if.md
@@ -11,9 +11,7 @@ The `if()` statement can also be used to test the value of certain system stores
 ## Syntax
 
 ```
-if(storeName comparison store2) ... > ...
 if(storeName comparison constant) ... > ...
-if(&systemStore comparison store2) ... > ...
 if(&systemStore comparison constant) ... > ...
 ```
 
@@ -35,9 +33,6 @@ if(&systemStore comparison constant) ... > ...
 
 `comparison`
 : Either `=` or `!=`, for equal and not equal, respectively.
-
-`store2`
-: The name of a store to compare to
 
 `constant`
 : A string value to compare to


### PR DESCRIPTION
While discussing [#13492](https://github.com/keymanapp/keyman/pull/13492) we discovered that the comparison with a store was never implemented. This change fixes the documentation to match reality.

Test-bot: skip