### PR TITLE
style: fix osk-phone images for keyboard help pages

### DIFF
--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -1192,6 +1192,7 @@ table.platform {
 #osk-phone,
 #osk-tablet{
 	position: relative;
+	z-index: 0;
 }
 
 #osk .kmw-osk-inner-frame{


### PR DESCRIPTION
Before:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/bd5ae9f0-af6b-4a6b-bb2d-523c460abbde" />
http://help.keyman.com.localhost:8055/keyboard/wali/1.0/wali#toc-touch-keyboard-layouts

After: 
<img width="500" alt="image" src="https://github.com/user-attachments/assets/15298880-8b83-41a0-8370-28b80c72af54" />

Test-bot: skip
