### PR TITLE
docs: context + keystroke model (vs sequences)

### DIFF
--- a/developer/language/guide/rules.md
+++ b/developer/language/guide/rules.md
@@ -47,9 +47,9 @@ example, in a Dinka keyboard, the following rule transforms "ee" on screen, when
 ### A sequence of keystrokes
 
 It is common to think of keyboard rules in terms of keystroke sequences. For
-example, in a Cyrillic keyboard, you may want <kbd>S</kbd><kbd>H</kbd> to
-produce "Ш". However, the <kbd>S</kbd> key by itself produces "С", and the
-<kbd>H</kbd> key on its own produces "Х".
+example, in an Armenian keyboard, you may want <kbd>D</kbd><kbd>Z</kbd> to
+produce "Ձ" (U+0541). However, the <kbd>D</kbd> key by itself produces "Դ"
+(U+0534), and the <kbd>Z</kbd> key on its own produces "Զ" (U+0536).
 
 Instead of thinking of a sequence of keystrokes, think of what is on screen
 already, and how it needs to change when you type the next keystroke.
@@ -57,18 +57,18 @@ already, and how it needs to change when you type the next keystroke.
 So, we would start with the following two rules for the keys on their own:
 
 ```keyman
-+ [SHIFT K_S] > 'С'
-+ [SHIFT K_H] > 'Х'
++ [SHIFT K_D] > 'Դ'   c U+0534
++ [SHIFT K_Z] > 'Զ'   c U+0536
 ```
 
-Then, instead of something like `'S' + 'H' > 'Ш'`, we would instead start with
-the _output_ of the <kbd>S</kbd> key ("С"), followed by the <kbd>H</kbd> key:
+Then, instead of something like `'D' + 'Z' > 'Ձ'`, we would instead start with
+the _output_ of the <kbd>D</kbd> key ("Դ"), followed by the <kbd>Z</kbd> key:
 
 ```keyman
-'С' + [SHIFT K_H] > 'Ш'
+'Դ' + [SHIFT K_Z] > 'Ձ'  c U+0541
 ```
 
-This new rule would take precedence over the <kbd>H</kbd> rule on its own,
+This new rule would take precedence over the <kbd>Z</kbd> rule on its own,
 because it has a longer context.
 
 ## Rule Order {#rule-order}


### PR DESCRIPTION
Requested by @mcdurdin,

> https://community.software.sil.org/t/how-to-code-in-ligatures-in-keyman/10905
> This question keeps coming up! Would you like to add a page to the documentation on the context + keystroke model (vs key sequences)? We have https://help.keyman.com/developer/language/guide/rules, but it might also be helpful to add an example or two at the top of that showing how a sequence could be implemented, something like:
> ```
> + 'A' > 'Ж'
> + 'B' > 'Z'
> 'Z' + 'A' > 'տ'
> ```

Test-bot: skip