### PR TITLE
Update kb0069.md

### DIFF
--- a/knowledge-base/kb0069.md
+++ b/knowledge-base/kb0069.md
@@ -18,8 +18,8 @@ This workaround enables you to type using Keyman keyboard in Adobe Acrobat Reade
 
 There is a second option to use Keyman keyboard in Adobe Acrobat Reader:
 1. Open editor of your choice e.g. Notepad
-2. type your text and paste it
-3. copy it into Adobe Acrobate Reader's search box, comment section or Fill & Sign
+2. type your text and copy it
+3. paste it into Adobe Acrobate Reader's search box, comment section or Fill & Sign
 
 This second workaround even overcomes the limitation w.r.t. Fill & Sign. However the combination **Windows on Arm** plus any **Khmer** keyboard (e.g. Keyman keyboard **Khmer Angkor**) does not work. Moreover using a Windows **Khmer** keyboard with **Windows on Arm** does not work either.
 

--- a/knowledge-base/kb0069.md
+++ b/knowledge-base/kb0069.md
@@ -7,7 +7,7 @@ When Adobe Acrobat Reader is open, you experience that you cannot type using a K
 The problem is that Adobe Acrobat Reader by default blocks all external applications from interaction, due to many longstanding security issues with it.
 
 ## Resolution
-Keyman for Windows 17 does not resolve the issue with Keyman keyboards not typing in Adobe Acrobat Reader. For a simple workaround, you can turn off Protected Mode in Adobe Acrobat Reader. Here's how:
+Keyman for Windows does not resolve the issue with Keyman keyboards not typing in Adobe Acrobat Reader. For a simple workaround, you can turn off Protected Mode in Adobe Acrobat Reader. Here's how:
 
 1. In Adobe Acrobat Reader, click on the top left menu button and select **Preferences**
 2. Under **Security (Enhanced)**, deselect **Enable Protected Mode at startup**
@@ -15,6 +15,13 @@ Keyman for Windows 17 does not resolve the issue with Keyman keyboards not typin
 4. Restart Adobe Acrobat Reader
 
 This workaround enables you to type using Keyman keyboard in Adobe Acrobat Reader in the search box and the comment section, but not in the Fill & Sign.
+
+There is a second option to use Keyman keyboard in Adobe Acrobat Reader:
+1. Open editor of your choice e.g. Notepad
+2. type your text and paste it
+3. copy it into Adobe Acrobate Reader's search box, comment section or Fill & Sign
+
+This second workaround even overcomes the limitation w.r.t. Fill & Sign. However the combination **Windows on Arm** plus any **Khmer** keyboard (e.g. Keyman keyboard **Khmer Angkor**) does not work. Moreover using a Windows **Khmer** keyboard with **Windows on Arm** does not work either.
 
 ## Applies to:
 * Keyman for Windows 14.0+


### PR DESCRIPTION
Adding another workaround for using Keyman keyboard in Adobe Acrobat Reader's search box, comment section and Fill & Sign.

Test-bot: skip
