### PR TITLE
fix: parse knowledge base article headings new line and tweak breadcrumbs

### DIFF
--- a/_includes/includes/template.php
+++ b/_includes/includes/template.php
@@ -100,10 +100,19 @@
   }
 
   function write_breadcrumbs(){
+    global $kb_title;
     $request_uri = explode("?",$_SERVER["REQUEST_URI"]);
     $crumbs = explode("/",$request_uri[0]);
     $crumbcount = count($crumbs);
     $crumbtrail = '';
+    if(sizeof($crumbs) > 1 && $crumbs[1] == 'knowledge-base') {
+      if(isset($_REQUEST['id'])) {
+        // KB articles are served by a single file, so we need to look for the
+        // global variable $kb_title to get the appropriate title, which is set
+        // in /knowledge-base/index.php.
+        $crumbs[2] = isset($kb_title) ? $kb_title : '';
+      }
+    }
     for($i=1; $i<$crumbcount; $i++){
       $crumb = ucfirst(str_replace(array(".php","_","-"),array(""," "," "),$crumbs[$i]) . ' ');
 

--- a/knowledge-base/index.php
+++ b/knowledge-base/index.php
@@ -55,8 +55,7 @@
       echo "<a href='".link_from_id($nid)."'>Next article &gt;</a> ";
     }
     echo "</p>";
-
-    } else {
+  } else {
     $query = trim($_GET['q'] ?? '');
     echo "<h1>Knowledge Base index</h1>";
     echo "<div class='search-bar'>";
@@ -84,6 +83,6 @@
         echo "<li><a href='".link_from_id($id)."'>KMKB{$matches[1]}: " . htmlspecialchars($title) . "</a></li>";
       }
     }
-  }
     echo "</ul>";
+  }
 ?>

--- a/knowledge-base/index.php
+++ b/knowledge-base/index.php
@@ -7,7 +7,7 @@
   use function com\keyman\help\kb\link_from_id;
 
   $id = null;
-  $title = 'Knowledge Base index';
+  $kb_title = 'Knowledge Base index';
 
   if(isset($_REQUEST['id'])) {
     $id = $_REQUEST['id'];
@@ -24,12 +24,12 @@
     } else {
       // We test the first line of the file for a title.
 
-      $text = explode('\n', $kb);
+      $text = explode("\n", $kb);
       if(count($text) > 0) {
         if(substr($text[0], 0, 2) == '# ') {
-          $title = trim(substr($text[0], 2));
+          $kb_title = trim(substr($text[0], 2)) . sprintf(" (KMKB%04.4d)", intval($id));
         } else {
-          $title = $filename;
+          $kb_title = $filename;
         }
       }
     }
@@ -37,25 +37,28 @@
 
   // Required
   head([
-    'title' =>'Keyman Support | ' . $title,
+    'title' =>'Keyman Support | ' . $kb_title,
     'css' => ['template.css','prism.css', 'kb-search.css'],
     'showMenu' => true,
     'index' => false
   ]);
-  echo "<h1>Knowledge Base index</h1>";
   if($id) {
-    echo "<p>";
+    $ParsedownAndAlerts = new \Keyman\Site\Common\GFMAlerts();
+    echo $ParsedownAndAlerts->text($kb);
+
+    echo "<hr><p>";
+    echo "<a href='/kb'>Knowledge Base index</a> &nbsp; | &nbsp; ";
     $pid = intval($id,10) - 1;
-    if($pid > 0) echo "<a href='".link_from_id($pid)."'>&lt; Previous article</a> &nbsp; ";
+    if($pid > 0) echo "<a href='".link_from_id($pid)."'>&lt; Previous article</a> &nbsp; | &nbsp; ";
     $nid = intval($id,10) + 1;
     if(file_exists(filename_from_id($nid))) {
       echo "<a href='".link_from_id($nid)."'>Next article &gt;</a> ";
     }
-    echo "</p><hr>";
-    $ParsedownAndAlerts = new \Keyman\Site\Common\GFMAlerts();
-    echo $ParsedownAndAlerts->text($kb);
-  } else {
+    echo "</p>";
+
+    } else {
     $query = trim($_GET['q'] ?? '');
+    echo "<h1>Knowledge Base index</h1>";
     echo "<div class='search-bar'>";
     echo "<form>";
     echo "<span class='search-icon'>🔍</span>";


### PR DESCRIPTION
The KB article was not being split correctly by line so the entire article was being reproduced in the title tag, and this also resulted in repeated headings.

At the same time, tweak the layout of the page to put the navigation at the end of the article, add the KMKBxxxx id to the title, and improve the breadcrumb navigation for KB articles.

## Header for article (breadcrumbs, title)

<img width="1287" height="268" alt="image" src="https://github.com/user-attachments/assets/f98110e0-a006-4544-afc9-add4beda90ec" />

## Footer for article (navigation)

<img width="1003" height="182" alt="image" src="https://github.com/user-attachments/assets/5fc3eef5-9731-4c62-b726-598f513fb540" />


Fixes: #2503
Test-bot: skip